### PR TITLE
Added ability to add extra tags to DataDog  (#11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target/*
 .classpath
 .project
 .settings/
+/work/
+nb-configuration.xml

--- a/pom.xml
+++ b/pom.xml
@@ -62,4 +62,32 @@
   		<version>4.2.5</version>
   	</dependency>
   </dependencies>
+  
+  <build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-site-plugin</artifactId>
+            <version>3.5</version>
+        </plugin>
+    </plugins>
+  </build>
+               
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>checkstyle</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
+    
 </project>

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DataDogJobProperty.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DataDogJobProperty.java
@@ -1,0 +1,128 @@
+package org.datadog.jenkins.plugins.datadog;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Descriptor;
+import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
+import hudson.model.Run;
+import java.io.IOException;
+import java.util.logging.Logger;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * Create a job property for use with DataDog plugin.
+ * @param <T>
+ */
+public class DataDogJobProperty<T extends Job<?,?>> extends JobProperty<T> {
+
+  private static final Logger LOGGER =  Logger.getLogger(DatadogBuildListener.class.getName());
+  private static final String DISPLAY_NAME = "DataDog Tagging";
+  private String tagging = null;
+  private boolean on;
+  private String tagFile = null;
+  
+  /**  
+   * This is a list of tagging targets to be submitted with the Build to DataDog.
+   * @return the tagging
+   */
+  public String getTagging() {
+    return tagging;
+  }
+
+  @DataBoundConstructor
+  public DataDogJobProperty( boolean on, String tagging, String tagFile ) { 
+    this.on = on;
+    this.tagFile = tagFile;
+    this.tagging = tagging;
+  }
+
+  @DataBoundSetter
+  public void setTagging(final String tagging) {
+    this.tagging = tagging;
+  }
+  
+  @Override
+  public JobProperty<?> reconfigure(StaplerRequest req, JSONObject form) 
+          throws Descriptor.FormException {
+    DataDogJobProperty prop = (DataDogJobProperty) super.reconfigure(req, form);
+    prop.tagFile = (String)form.getJSONObject("choice").get("tagFile");
+    prop.tagging = (String)form.getJSONObject("choice").get("tagging");
+    return prop;
+  }
+ 
+  /**
+   * @return the enabled
+   */
+  public boolean isOn() {
+    return on;
+  }
+
+  /**
+   * @param on the enabled to set
+   */
+  @DataBoundSetter
+  public void setOn(boolean on) {
+    this.on = on;
+  }
+
+  /**
+   * @return the tagFile
+   */
+  public String getTagFile() {
+    return tagFile;
+  }
+
+  /**
+   * @param tagFile the tagFile to set
+   */
+  @DataBoundSetter
+  public void setTagFile(String tagFile) {
+    this.tagFile = tagFile;
+  }
+  
+  public boolean isTagFileEmpty() {
+    return StringUtils.isBlank(tagFile);
+  }
+
+  public boolean isTaggingEmpty() {
+    return StringUtils.isBlank(tagging);
+  }
+  
+  public String readTagFile(Run r) {
+    String s = null;
+    try {      
+      FilePath path = new FilePath(r.getExecutor().getCurrentWorkspace(), 
+              tagFile);      
+      if(path.exists()) {
+        s = path.readToString();
+      }
+    } catch (IOException ex) {
+      LOGGER.severe(ex.getMessage());
+    } catch (InterruptedException ex) {
+      LOGGER.severe(ex.getMessage());
+    }
+    return s;
+  }
+
+  @Extension
+  public static final class DataDogJobPropertyDescriptorImpl 
+    extends JobPropertyDescriptor {
+    
+    @Override
+    public String getDisplayName() {
+        return DISPLAY_NAME;
+    }
+
+    @Override
+    public boolean isApplicable(Class<? extends Job> jobType) {
+        return true;
+    }
+
+  }
+}

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DataDogJobProperty.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DataDogJobProperty.java
@@ -50,9 +50,16 @@ public class DataDogJobProperty<T extends Job<?,?>> extends JobProperty<T> {
   @Override
   public JobProperty<?> reconfigure(StaplerRequest req, JSONObject form) 
           throws Descriptor.FormException {
+
     DataDogJobProperty prop = (DataDogJobProperty) super.reconfigure(req, form);
     prop.tagFile = (String)form.getJSONObject("choice").get("tagFile");
     prop.tagging = (String)form.getJSONObject("choice").get("tagging");
+    
+    if(!on) {
+      prop.tagFile = null;
+      prop.tagging = null;
+    }
+    
     return prop;
   }
  

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -21,25 +21,27 @@ import net.sf.json.JSONSerializer;
 
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.export.Exported;
 
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PrintStream;
 import java.net.HttpURLConnection;
 import java.net.Inet4Address;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * DatadogBuildListener {@link RunListener}.
@@ -85,6 +87,48 @@ public class DatadogBuildListener extends RunListener<Run>
    * Runs when the {@link DatadogBuildListener} class is created.
    */
   public DatadogBuildListener() { }
+   
+  @Nonnull
+  private HashMap<String,String> parseTagList(Run run, TaskListener listener) throws IOException,
+          InterruptedException {
+    HashMap<String,String> map = new HashMap<String, String>();
+    
+    DataDogJobProperty property = (DataDogJobProperty)run.getParent()
+            .getProperty(DataDogJobProperty.class);
+    String prop = property.getTagging();
+    String file = property.getTagFile();
+    
+    PrintStream console = listener.getLogger();
+    
+    if( !StringUtils.isBlank(file)) {
+      String dataFromFile = property.readTagFile(run);
+      if(dataFromFile != null) {
+        for(String tag : dataFromFile.split("\\r?\\n")) {    
+          String[] expanded = run.getEnvironment(listener).expand(tag).split("=");
+          if( expanded.length > 1 ) {
+            map.put(expanded[0], expanded[1]);
+            console.println(String.format("Emitted tag %s:%s", expanded[0], expanded[1]));
+          } else {
+            logger.fine(String.format("Ignoring the tag %s. It is empty.", tag));
+          }
+        }
+      }
+    }
+      
+    if( !StringUtils.isBlank(prop)  ) {
+      for(String tag : prop.split("\\r?\\n")) {    
+        String[] expanded = run.getEnvironment(listener).expand(tag).split("=");
+        if( expanded.length > 1 ) {
+          map.put(expanded[0], expanded[1]);
+          console.println(String.format("Emitted tag %s:%s", expanded[0], expanded[1]));
+        } else {
+          logger.fine(String.format("Ignoring the tag %s. It is empty.", tag));
+        }
+      }
+    }
+    
+    return map;
+  }
 
   /**
    * Called when a build is first started.
@@ -96,7 +140,7 @@ public class DatadogBuildListener extends RunListener<Run>
   @Override
   public final void onStarted(final Run run, final TaskListener listener) {
     String jobName = run.getParent().getDisplayName();
-
+    HashMap<String,String> tags = new HashMap<String,String>();    
     // Process only if job is NOT in blacklist
     if ( isJobTracked(jobName) ) {
       logger.fine("Started build!");
@@ -105,6 +149,7 @@ public class DatadogBuildListener extends RunListener<Run>
       EnvVars envVars = null;
       try {
         envVars = run.getEnvironment(listener);
+        tags = parseTagList(run, listener);
       } catch (IOException e) {
         logger.severe(e.getMessage());
       } catch (InterruptedException e) {
@@ -124,8 +169,7 @@ public class DatadogBuildListener extends RunListener<Run>
 
       // Add event_type to assist in roll-ups
       builddata.put("event_type", "build start"); // string
-
-      event(builddata);
+      event(builddata, tags);
     }
   }
 
@@ -136,27 +180,35 @@ public class DatadogBuildListener extends RunListener<Run>
    * @param listener - A TaskListener object which receives events that happen during some
    *                   operation.
    */
+  
   @Override
   public final void onCompleted(final Run run, @Nonnull final TaskListener listener) {
     final String jobName = run.getParent().getDisplayName();
-
     // Process only if job in NOT in blacklist
     if ( isJobTracked(jobName) ) {
       logger.fine("Completed build!");
 
       // Collect Data
       JSONObject builddata = gatherBuildMetadata(run, listener);
+      HashMap<String,String> extraTags = new HashMap<String, String>();
+      try {
+        extraTags = parseTagList(run, listener);
+      } catch (IOException ex) {
+        logger.severe(ex.getMessage());
+      } catch (InterruptedException ex) {
+        logger.severe(ex.getMessage());
+      }
 
       // Add event_type to assist in roll-ups
       builddata.put("event_type", "build result"); // string
 
       // Report Data
-      event(builddata);
-      gauge("jenkins.job.duration", builddata, "duration");
+      event(builddata, extraTags);
+      gauge("jenkins.job.duration", builddata, "duration", extraTags);      
       if ( "SUCCESS".equals(builddata.get("result")) ) {
-        serviceCheck("jenkins.job.status", DatadogBuildListener.OK, builddata);
+        serviceCheck("jenkins.job.status", DatadogBuildListener.OK, builddata, extraTags);
       } else {
-        serviceCheck("jenkins.job.status", DatadogBuildListener.CRITICAL, builddata);
+        serviceCheck("jenkins.job.status", DatadogBuildListener.CRITICAL, builddata, extraTags);
       }
     }
   }
@@ -195,13 +247,12 @@ public class DatadogBuildListener extends RunListener<Run>
     builddata.put("hostname", getHostname(envVars)); // string
     builddata.put("buildurl", envVars.get("BUILD_URL")); // string
     builddata.put("node", envVars.get("NODE_NAME")); // string
-
+     
     if ( envVars.get("GIT_BRANCH") != null ) {
       builddata.put("branch", envVars.get("GIT_BRANCH")); // string
     } else if ( envVars.get("CVS_BRANCH") != null ) {
       builddata.put("branch", envVars.get("CVS_BRANCH")); // string
     }
-
     return builddata;
   }
 
@@ -211,21 +262,31 @@ public class DatadogBuildListener extends RunListener<Run>
    * of tags.
    *
    * @param builddata - A JSONObject containing a builds metadata.
+   * @param extra - A list of tags, that are contributed via {@link DataDogJobProperty}.   
    * @return a JSONArray containing a specific subset of tags retrieved from a builds metadata.
    */
-  private JSONArray assembleTags(final JSONObject builddata) {
+  private JSONArray assembleTags(final JSONObject builddata, final HashMap<String,String> extra) {
     JSONArray tags = new JSONArray();
+    
     tags.add("job:" + builddata.get("job"));
     if ( (builddata.get("node") != null) && getDescriptor().getTagNode() ) {
       tags.add("node:" + builddata.get("node"));
     }
+    
     if ( builddata.get("result") != null ) {
       tags.add("result:" + builddata.get("result"));
     }
-    if ( builddata.get("branch") != null ) {
+    
+    if ( builddata.get("branch") != null && !extra.containsKey("branch") ) {
       tags.add("branch:" + builddata.get("branch"));
     }
-
+    
+    //Add the extra tags here
+    for(String key : extra.keySet()) {
+      tags.add(String.format("%s:%s", key, extra.get(key)));
+      logger.info(String.format("Emitted tag %s:%s", key, extra.get(key)));
+    }
+    
     return tags;
   }
 
@@ -298,16 +359,19 @@ public class DatadogBuildListener extends RunListener<Run>
    * @param builddata - A JSONObject containing a builds metadata.
    * @param key - A String with the name of the build metadata to be found in the {@link JSONObject}
    *              builddata.
+   * @param extraTags - A list of tags, that are contributed via {@link DataDogJobProperty}. 
    */
   public final void gauge(final String metricName, final JSONObject builddata,
-                          final String key) {
+                          final String key, final HashMap<String,String> extraTags) {
     String builddataKey = nullSafeGetString(builddata, key);
     logger.fine(String.format("Sending metric '%s' with value %s", metricName, builddataKey));
 
     // Setup data point, of type [<unix_timestamp>, <value>]
     JSONArray points = new JSONArray();
     JSONArray point = new JSONArray();
-    point.add(System.currentTimeMillis() / DatadogBuildListener.THOUSAND_LONG); // current time, s
+    
+    long currentTime = System.currentTimeMillis() / DatadogBuildListener.THOUSAND_LONG;    
+    point.add(currentTime); // current time, s
     point.add(builddata.get(key));
     points.add(point); // api expects a list of points
 
@@ -317,15 +381,17 @@ public class DatadogBuildListener extends RunListener<Run>
     metric.put("points", points);
     metric.put("type", "gauge");
     metric.put("host", builddata.get("hostname"));
-    metric.put("tags", assembleTags(builddata));
-
+    metric.put("tags", assembleTags(builddata, extraTags));
+    
     // Place metric as item of series list
     JSONArray series = new JSONArray();
     series.add(metric);
-
+    
     // Add series to payload
     JSONObject payload = new JSONObject();
     payload.put("series", series);
+    
+    logger.fine(String.format("Resulting payload: %s", payload.toString() ));
 
     try {
       post(payload, DatadogBuildListener.METRIC);
@@ -340,9 +406,10 @@ public class DatadogBuildListener extends RunListener<Run>
    * @param checkName - A String with the name of the service check to record.
    * @param status - An Integer with the status code to record for this service check.
    * @param builddata - A JSONObject containing a builds metadata.
+   * @param extraTags - A list of tags, that are contributed through the {@link DataDogJobProperty}. 
    */
   public final void serviceCheck(final String checkName, final Integer status,
-                                 final JSONObject builddata) {
+                                 final JSONObject builddata, final HashMap<String,String> extraTags) {
     logger.fine(String.format("Sending service check '%s' with status %s", checkName, status));
 
     // Build payload
@@ -352,7 +419,7 @@ public class DatadogBuildListener extends RunListener<Run>
     payload.put("timestamp",
                 System.currentTimeMillis() / DatadogBuildListener.THOUSAND_LONG); // current time, s
     payload.put("status", status);
-    payload.put("tags", assembleTags(builddata));
+    payload.put("tags", assembleTags(builddata, extraTags));
 
     try {
       post(payload, DatadogBuildListener.SERVICECHECK);
@@ -365,8 +432,9 @@ public class DatadogBuildListener extends RunListener<Run>
    * Sends a an event to the Datadog API, including the event payload.
    *
    * @param builddata - A JSONObject containing a builds metadata.
+   * @param extraTags - A list of tags, that are contributed through the {@link DataDogJobProperty}. 
    */
-  public final void event(final JSONObject builddata) {
+  public final void event(final JSONObject builddata, HashMap<String,String> extraTags) {
     logger.fine("Sending event");
 
     // Gather data
@@ -414,7 +482,7 @@ public class DatadogBuildListener extends RunListener<Run>
     payload.put("event_type", builddata.get("event_type"));
     payload.put("host", hostname);
     payload.put("result", builddata.get("result"));
-    payload.put("tags", assembleTags(builddata));
+    payload.put("tags", assembleTags(builddata, extraTags));
     payload.put("aggregation_key", job); // Used for job name in event rollups
 
     try {

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DataDogJobProperty/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DataDogJobProperty/config.jelly
@@ -1,0 +1,14 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:optionalBlock name="on" checked="${instance.on}" title="DataDog tagging" inline="true">
+        <f:radioBlock title="Properties content" name="choice" checked="${!instance.isTaggingEmpty()}">
+            <f:entry title="Properties" field="tagging">    
+                <f:textarea/>
+            </f:entry>            
+        </f:radioBlock>   
+        <f:radioBlock title="File from workspace" name="choice" checked="${!instance.isTagFileEmpty()}">
+            <f:entry title="File" field="tagFile">
+                <f:textbox/>
+            </f:entry>
+        </f:radioBlock>
+    </f:optionalBlock>
+</j:jelly>

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DataDogJobProperty/help-tagFile.html
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DataDogJobProperty/help-tagFile.html
@@ -1,0 +1,6 @@
+<div>
+    <p>Read a file from workspace as a newline seperated list of tags to push to DataDog. Location is relative to workspace</p>
+    <p>Example: <em>os=${OS_PARAM}</em>.</p> 
+    <p>The value can either be something that is automatically expanded in Jenkins, or a static value which you define for the tag</p>
+    <p>The OS_PARAM in this case is a value that is expanded by Jenkins (Environment and/or build variable)</p>
+</div>

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DataDogJobProperty/help-tagging.html
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DataDogJobProperty/help-tagging.html
@@ -1,0 +1,6 @@
+<div>
+    <p>A newline separated list of tags to push to DataDog. Tags MUST follow the format <em>key:value</em>.<p>
+    <p>Example: <em>os=${OS_PARAM}</em>.</p> 
+    <p>The value can either be something that is automatically expanded in Jenkins, or a static value which you define for the tag</p>
+    <p>The OS_PARAM in this case is a value that is expanded by Jenkins (Environment and/or build variable)</p>
+</div>


### PR DESCRIPTION
This is the first proposal for fixing issue #11

The pull request adds the ability to add tags to DataDog. 

![ui_element_ddplugin](https://cloud.githubusercontent.com/assets/1484793/13632024/f72986bc-e5e7-11e5-8a2f-5ca36fd5863d.png)

Tags can be added by reading a file, or entering a properties file that follows the standard java property file syntax: {k}={v}. The value can here be something that is expanded by Jenkins, for example an environment variable or a build parameter or a fixed value. 

The tags are added to event, metric and the service check. 

Comments are welome.


 