### PR TITLE
Stop statsd client after sending data

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -168,14 +168,19 @@ public class DatadogBuildListener extends RunListener<Run>
 
       if(DatadogUtilities.isValidDaemon(getDescriptor().getDaemonHost()))  {
         logger.fine(String.format("Sending completed counter to %s ", getDescriptor().getDaemonHost()));
+        StatsDClient statsd = null;
         try {
           //The client is a threadpool so instead of creating a new instance of the pool
           //we lease the exiting one registerd with Jenkins.
-          StatsDClient statsd = getDescriptor().leaseClient();
+          statsd = getDescriptor().leaseClient();
           statsd.increment("completed", tagsToCounter);
           logger.fine("Jenkins completed counter sent!");
         } catch (StatsDClientException e) {
           logger.log(Level.SEVERE, "Runtime exception thrown using the StatsDClient", e);
+        } finally {
+          if(statsd != null){
+            statsd.stop();
+          }
         }
       } else {
         logger.warning("Invalid dogstats daemon host specificed");


### PR DESCRIPTION
The implementation creates a new DescriptorImpl instance for every call
to onCompleted. For every new instance a new statsd client is created.
The statsd client is never stopped. This causes a resource(thread) leak.
The resource leak will cause a `java.lang.OutOfMemoryError: Unable to create new native thread`
How fast this happens depends on how often jobs are executed and the OS
https://plumbr.eu/outofmemoryerror/unable-to-create-new-native-thread#example