### PR TITLE
[JENKINS-55787] Switch labels from entry to checkbox

### DIFF
--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -73,12 +73,12 @@
           <f:textarea field="globalJobTags" optional="true" default="${globalJobTags}" />
         </f:entry>
 
-        <f:entry title="Send Security audit events" description="Send security events like login, logout, login failure, configuration changes to jobs or changes to jenkins.">
-            <f:checkbox field="emitSecurityEvents" default="true"/>
+        <f:entry description="Send security events like login, logout, login failure, configuration changes to jobs or changes to jenkins.">
+            <f:checkbox title="Send Security audit events" field="emitSecurityEvents" default="true"/>
         </f:entry>
 
-        <f:entry title="Send System events" description="Send system events like Node changes of states.">
-            <f:checkbox field="emitSystemEvents" default="true"/>
+        <f:entry description="Send system events like Node changes of states.">
+            <f:checkbox title="Send System events" field="emitSystemEvents" default="true"/>
         </f:entry>
     </f:advanced>
   </f:section>

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogJobProperty/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogJobProperty/config.jelly
@@ -15,8 +15,8 @@
         </f:optionalBlock>
 
         <f:advanced>
-            <f:entry title="Send Source Control Management events" description="Send an event after each successful checkout.">
-                <f:checkbox field="emitSCMEvents" default="true"/>
+            <f:entry description="Send an event after each successful checkout.">
+                <f:checkbox title="Send Source Control Management events" field="emitSCMEvents" default="true"/>
             </f:entry>
         </f:advanced>
 


### PR DESCRIPTION
[JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787)

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.

Before:
![image](https://user-images.githubusercontent.com/2119212/52803388-f60b5c00-304f-11e9-9526-131c44baedee.png)
(Note: the above looks really bad...)

Before*:
![image](https://user-images.githubusercontent.com/2119212/52776089-fc2d1880-300e-11e9-966f-e9871f0ad6a5.png)

After:
![image](https://user-images.githubusercontent.com/2119212/52776114-00593600-300f-11e9-8a4f-399e71fcddf6.png)

* This is using my UI modifications which replaces most tables (the table dropping commit is for the benefit of that)