### PR TITLE
Avoid constructing DatadogBuildListener.DescriptorImpl instances

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -32,7 +32,6 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.concurrent.TimeUnit;
@@ -382,7 +381,7 @@ public class DatadogBuildListener extends RunListener<Run>
    */
   @Override
   public DescriptorImpl getDescriptor() {
-    return new DescriptorImpl();
+    return DatadogUtilities.getDatadogDescriptor();
   }
 
   /**


### PR DESCRIPTION
…as that breaks caching of `leaseClient`, and may cause other problems as well. Found by an instrumented runtime that every build created a new thread pool:

```
	at java.util.concurrent.Executors$DefaultThreadFactory.<init>(Executors.java:610)
	at java.util.concurrent.Executors.defaultThreadFactory(Executors.java:353)
	at com.timgroup.statsd.NonBlockingStatsDClient$3.<init>(NonBlockingStatsDClient.java:77)
	at com.timgroup.statsd.NonBlockingStatsDClient.<init>(NonBlockingStatsDClient.java:76)
	at com.timgroup.statsd.NonBlockingStatsDClient.<init>(NonBlockingStatsDClient.java:108)
	at org.datadog.jenkins.plugins.datadog.DatadogBuildListener$DescriptorImpl.leaseClient(DatadogBuildListener.java:405)
	at org.datadog.jenkins.plugins.datadog.DatadogBuildListener.onCompleted(DatadogBuildListener.java:202)
	at hudson.model.listeners.RunListener.fireCompleted(RunListener.java:209)
	at …
```

_Untested_.