### PR TITLE
Bump days before close in stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,6 +28,7 @@ jobs:
 
             1. Comment that the issue is still reproducible and include updated details requested in the issue template.
         days-before-stale: 30
+        days-before-close: 99999
         stale-issue-label: 'stale'
         exempt-issue-label: 'stale/exempt'
         stale-pr-message: >-


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Bumps the number of days it takes for stale action to close a stale issue/pr

### Description of the Change

The default for this setting is 7 days, but our message states we won't close an issue. While the stale action doesn't currently support not closing this issue, this gives an arbitrarily high value before its closed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

