### PR TITLE
Add log collection

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -141,3 +141,13 @@ To spin up a development environment for the *jenkins-datadog* plugin repository
 ## Continuous Integration
 
 Every commit to the repository triggers the [Jenkins Org CI pipeline](https://jenkins.io/doc/developer/publishing/continuous-integration/) defined in the `Jenkinsfile` at the root folder of the source code.
+
+## Troubleshooting
+
+### Header is too large
+
+When accessing your jenkins instance, you may run into the following warning
+```
+WARNING o.eclipse.jetty.http.HttpParser#parseFields: Header is too large 8193>8192
+```
+In this case, use your browser in incognito mode.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,7 +77,7 @@ To spin up a development environment for the *jenkins-datadog* plugin repository
     #      - $JENKINS_PLUGIN/conf.yaml:/etc/datadog-agent/conf.d/jenkins.d/conf.yaml   
                
     ```
-1. If you wish to submit log using the Datadog Agent, you will have to configure the Datadog Agent properly by creating a conf.yaml file with the following content.
+1. If you wish to submit log using the Datadog Agent, you will have to configure the Datadog Agent properly by creating a `conf.yaml` file with the following content.
 
     ```
     logs:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,14 +44,54 @@ To spin up a development environment for the *jenkins-datadog* plugin repository
           - 8080:8080
         volumes:
           - $JENKINS_PLUGIN/target/:/var/jenkins_home/plugins
+    ## Uncomment environment variables based on your needs. Everything can be configured in jenkins /configure page as well. 
+    #      - DATADOG_JENKINS_PLUGIN_REPORT_WITH=DSD
+    #      - DATADOG_JENKINS_PLUGIN_COLLECT_BUILD_LOGS=false
+    ## Set `DATADOG_JENKINS_PLUGIN_TARGET_HOST` to `dogstatsd` or `datadog` based on the container you wish to use.
+    #      - DATADOG_JENKINS_PLUGIN_TARGET_HOST=dogstatsd
+    #      - DATADOG_JENKINS_PLUGIN_TARGET_LOG_COLLECTION_PORT=10518
+    #      - DATADOG_JENKINS_PLUGIN_TARGET_API_KEY=$JENKINS_PLUGIN_DATADOG_API_KEY
+      
+    ## Uncomment the section below to use the standalone DogStatsD server to send metrics to Datadog
+    #  dogstatsd:
+    #    image: datadog/dogstatsd:latest
+    #    environment:
+    #      - DD_API_KEY=$JENKINS_PLUGIN_DATADOG_API_KEY
+    #    ports:
+    #      - 8125:8125
+    
+    ## Uncomment the section below to use the whole Datadog Agent to send metrics (and logs) to Datadog. 
+    ## Note that it contains a DogStatsD server as well.
+    #  datadog:
+    #    image: datadog/agent:latest
+    #    environment:
+    #      - DD_API_KEY=$JENKINS_PLUGIN_DATADOG_API_KEY
+    #      - DD_LOGS_ENABLED=true
+    #     ports:
+    #       - 8125:8125
+    #       - 10518:10518
+    #    volumes:
+    #      - /var/run/docker.sock:/var/run/docker.sock:ro
+    #      - /proc/:/host/proc/:ro
+    #      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+    #      - $JENKINS_PLUGIN/conf.yaml:/etc/datadog-agent/conf.d/jenkins.d/conf.yaml   
                
     ```
+1. If you wish to submit log using the Datadog Agent, you will have to configure the Datadog Agent properly by creating a conf.yaml file with the following content.
 
-2. Set the `JENKINS_PLUGIN` environment variable to point to the directory where this repository is cloned/forked.
-3. Run `docker-compose -f <DOCKER_COMPOSE_FILE_PATH> up`.
+    ```
+    logs:
+      - type: tcp
+        port: 10518
+        service: "jenkins"
+        source: "jenkins"
+    ```
+1. Set the `JENKINS_PLUGIN` environment variable to point to the directory where this repository is cloned/forked.
+1. Set the `JENKINS_PLUGIN_DATADOG_API_KEY` environment variable with your api key.
+1. Run `docker-compose -f <DOCKER_COMPOSE_FILE_PATH> up`.
     - NOTE: This spins up the Jenkins docker image and auto mount the target folder of this repository (the location where the binary is built)
     - NOTE: To see code updates, after re building the provider with `mvn clean package` on your local machine, run `docker-compose down` and spin this up again.
-4. Check your terminal and look for the admin password:
+1. Check your terminal and look for the admin password:
     ```
     jenkins_1    | *************************************************************
     jenkins_1    | *************************************************************
@@ -69,13 +109,13 @@ To spin up a development environment for the *jenkins-datadog* plugin repository
     jenkins_1    | *************************************************************
     ``` 
 
-5. Access your Jenkins instance http://localhost:8080
-6. Enter the administrator password in the Getting Started form.
-7. On the next page, click on the "Select plugins to be installed" unless you want to install all suggested plugins. 
-8. Select desired plugins depending on your needs. You can always add plugins later.
-9. Create a user so that you don't have to use the admin credential again (optional).
-10. Continue until the end of the setup process and log back in.
-11. Go to http://localhost:8080/configure to configure the "Datadog Plugin", set your `API Key`.
+1. Access your Jenkins instance http://localhost:8080
+1. Enter the administrator password in the Getting Started form.
+1. On the next page, click on the "Select plugins to be installed" unless you want to install all suggested plugins. 
+1. Select desired plugins depending on your needs. You can always add plugins later.
+1. Create a user so that you don't have to use the admin credential again (optional).
+1. Continue until the end of the setup process and log back in.
+1. Go to http://localhost:8080/configure to configure the "Datadog Plugin", set your `API Key`.
   - Click on the "Test Key" to make sure your key is valid.
   - You can set your machine `hostname`.
   - You can set Global Tag. For example `.*, owner:$1, release_env:$2, optional:Tag3`.
@@ -83,8 +123,8 @@ To spin up a development environment for the *jenkins-datadog* plugin repository
 ### Create your first job
 
 1. On jenkins Home page, click on "Create a new Job" 
-2. Give it a name and select "freestyle project".
-3. Then add a build step (execute Shell):
+1. Give it a name and select "freestyle project".
+1. Then add a build step (execute Shell):
     ```
     #!/bin/sh
     
@@ -94,9 +134,9 @@ To spin up a development environment for the *jenkins-datadog* plugin repository
 
 ### Create Logger
 1. Go to http://localhost:8080/log/
-2. Give a name to your logger - For example `datadog`
-3. Add entries for all `org.datadog.jenkins.plugins.datadog.*` packages with log Level `ALL`.
-4. If you now run a job and go back to http://localhost:8080/log/datadog/, you should see your logs
+1. Give a name to your logger - For example `datadog`
+1. Add entries for all `org.datadog.jenkins.plugins.datadog.*` packages with log Level `ALL`.
+1. If you now run a job and go back to http://localhost:8080/log/datadog/, you should see your logs
 
 ## Continuous Integration
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ From the global configuration page, at `Manage Jenkins -> Configure System` you 
 | Global job tags            | A comma separated list of regex to match a job and a list of tags to apply to that job. **Note**: Tags can reference match groups in the regex using the `$` symbol, for example: `(.*?)_job_(*?)_release, owner:$1, release_env:$2, optional:Tag3` | `DATADOG_JENKINS_PLUGIN_GLOBAL_JOB_TAGS`      |
 | Send security audit events | Submits the `Security Events Type` of events and metrics (enabled by default).                                                                                                                                                                | `DATADOG_JENKINS_PLUGIN_EMIT_SECURITY_EVENTS` |
 | Send system events         | Submits the `System Events Type` of events and metrics (enabled by default).                                                                                                                                                                  | `DATADOG_JENKINS_PLUGIN_EMIT_SYSTEM_EVENTS`   |
-| Enable Log Collection      | Submits build logs (disabled by default).                                                                                                                                                                  | `DATADOG_JENKINS_PLUGIN_ENABLE_LOG_COLLECTION`   |
+| Enable Log Collection      | Collect and Submit build logs (disabled by default).                                                                                                                                                                  | `DATADOG_JENKINS_PLUGIN_COLLECT_BUILD_LOGS`   |
 
 ### Job customization
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ This plugin can be installed from the [Update Center][3] (found at `Manage Jenki
 
 You can use two ways to configure your plugin to submit data to Datadog:
 
-* Sending the data directly to Datadog through HTTP.
-* Using a DogStatsD server that acts as a forwarder between Jenkins and Datadog.
+* **RECOMMENDED**: Using a DogStatsD server / Datadog Agent that acts as a forwarder between Jenkins and Datadog.
+  - Build Logs collection only works with a full Datadog Agent installed.
+* Sending data directly to Datadog through HTTP.
+  - The HTTP client implementation used is blocking with a timeout duration of 1 minute. If there is a connection problem with Datadog, it will slow your Jenkins instance down.
 
 The configuration can be done from the [plugin user interface](#plugin-user-interface) with a [Groovy script](#groovy-script), or through [environment variables](#environment-variables).
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can use two ways to configure your plugin to submit data to Datadog:
 * **RECOMMENDED**: Using a DogStatsD server / Datadog Agent that acts as a forwarder between Jenkins and Datadog.
   - Build Logs collection only works with a full Datadog Agent installed.
 * Sending data directly to Datadog through HTTP.
-  - The HTTP client implementation used is blocking with a timeout duration of 1 minute. If there is a connection problem with Datadog, it will slow your Jenkins instance down.
+  - The HTTP client implementation used is blocking with a timeout duration of 1 minute. If there is a connection problem with Datadog, it may slow your Jenkins instance down.
 
 The configuration can be done from the [plugin user interface](#plugin-user-interface) with a [Groovy script](#groovy-script), or through [environment variables](#environment-variables).
 

--- a/README.md
+++ b/README.md
@@ -96,14 +96,16 @@ Configure your Datadog plugin using environment variables with the `DATADOG_JENK
 ##### HTTP forwarding {#http-forwarding-env}
 
 1. Set the `DATADOG_JENKINS_PLUGIN_REPORT_WITH` variable to `HTTP`.
-2. Set the `DATADOG_JENKINS_PLUGIN_TARGET_API_URL` variable, which specifies the Datadog API endpoint (defaults `https://api.datadoghq.com/api/`).
+2. Set the `DATADOG_JENKINS_PLUGIN_TARGET_API_URL` variable, which specifies the Datadog API endpoint (defaults to `https://api.datadoghq.com/api/`).
 3. Set the `DATADOG_JENKINS_PLUGIN_TARGET_API_KEY` variable, which specifies your [Datadog API key][4].
+4. (optional) Set the `DATADOG_JENKINS_PLUGIN_TARGET_LOG_INTAKE_URL` variable, which specifies the Datadog Log Intake URL (defaults to `https://http-intake.logs.datadoghq.com/v1/input/`).
 
 ##### DogStatsD forwarding {#dogstatsd-forwarding-env}
 
 1. Set the `DATADOG_JENKINS_PLUGIN_REPORT_WITH` variable to `DSD`.
 2. Set the `DATADOG_JENKINS_PLUGIN_TARGET_HOST` variable, which specifies the DogStatsD server host (defaults to `localhost`).
 3. Set the `DATADOG_JENKINS_PLUGIN_TARGET_PORT` variable, which specifies the DogStatsD server port (defaults to `8125`).
+4. (optional) Set the `DATADOG_JENKINS_PLUGIN_TARGET_LOG_COLLECTION_PORT` variable, which specifies the Datadog Agent log collection port.
 
 #### Logging
 
@@ -124,6 +126,7 @@ From the global configuration page, at `Manage Jenkins -> Configure System` you 
 | Global job tags            | A comma separated list of regex to match a job and a list of tags to apply to that job. **Note**: Tags can reference match groups in the regex using the `$` symbol, for example: `(.*?)_job_(*?)_release, owner:$1, release_env:$2, optional:Tag3` | `DATADOG_JENKINS_PLUGIN_GLOBAL_JOB_TAGS`      |
 | Send security audit events | Submits the `Security Events Type` of events and metrics (enabled by default).                                                                                                                                                                | `DATADOG_JENKINS_PLUGIN_EMIT_SECURITY_EVENTS` |
 | Send system events         | Submits the `System Events Type` of events and metrics (enabled by default).                                                                                                                                                                  | `DATADOG_JENKINS_PLUGIN_EMIT_SYSTEM_EVENTS`   |
+| Enable Log Collection      | Submits build logs (disabled by default).                                                                                                                                                                  | `DATADOG_JENKINS_PLUGIN_ENABLE_LOG_COLLECTION`   |
 
 ### Job customization
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,9 +19,7 @@ This project does not have a strict release schedule. However, we would make a r
 * Manually test changes included in the new release.
 * Make sure documentation is up-to-date.
 * [Update changelog](#update-changelog)
-  - Create a distinct pull request.
-* **IMPORTANT**: Update Plugin version in this following method.
-  - `org.datadog.jenkins.plugins.datadog.DatadogUtilities.getDatadogPluginVersion`  
+  - Create a distinct pull request. 
 
 ## Update Changelog
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,6 +20,8 @@ This project does not have a strict release schedule. However, we would make a r
 * Make sure documentation is up-to-date.
 * [Update changelog](#update-changelog)
   - Create a distinct pull request.
+* **IMPORTANT**: Update Plugin version in this following method.
+  - `org.datadog.jenkins.plugins.datadog.DatadogUtilities.getDatadogPluginVersion`  
 
 ## Update Changelog
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,30 +75,6 @@
   </dependencies>
 
   <build>
-    <!--&lt;!&ndash; To define the plugin version in your parent POM &ndash;&gt;-->
-    <!--<pluginManagement>-->
-      <!--<plugins>-->
-        <!--<plugin>-->
-          <!--<groupId>org.apache.maven.plugins</groupId>-->
-          <!--<artifactId>maven-resources-plugin</artifactId>-->
-          <!--<version>3.1.0</version>-->
-        <!--</plugin>-->
-      <!--</plugins>-->
-    <!--</pluginManagement>-->
-    <!--&lt;!&ndash; To use the plugin goals in your POM or parent POM &ndash;&gt;-->
-    <!--<plugins>-->
-      <!--<plugin>-->
-        <!--<groupId>org.apache.maven.plugins</groupId>-->
-        <!--<artifactId>maven-resources-plugin</artifactId>-->
-        <!--<version>3.1.0</version>-->
-      <!--</plugin>-->
-    <!--</plugins>-->
-    <!--<resources>-->
-      <!--<resource>-->
-        <!--<directory>src/main/resources</directory>-->
-        <!--<filtering>true</filtering>-->
-      <!--</resource>-->
-    <!--</resources>-->
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,4 +74,45 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <!--&lt;!&ndash; To define the plugin version in your parent POM &ndash;&gt;-->
+    <!--<pluginManagement>-->
+      <!--<plugins>-->
+        <!--<plugin>-->
+          <!--<groupId>org.apache.maven.plugins</groupId>-->
+          <!--<artifactId>maven-resources-plugin</artifactId>-->
+          <!--<version>3.1.0</version>-->
+        <!--</plugin>-->
+      <!--</plugins>-->
+    <!--</pluginManagement>-->
+    <!--&lt;!&ndash; To use the plugin goals in your POM or parent POM &ndash;&gt;-->
+    <!--<plugins>-->
+      <!--<plugin>-->
+        <!--<groupId>org.apache.maven.plugins</groupId>-->
+        <!--<artifactId>maven-resources-plugin</artifactId>-->
+        <!--<version>3.1.0</version>-->
+      <!--</plugin>-->
+    <!--</plugins>-->
+    <!--<resources>-->
+      <!--<resource>-->
+        <!--<directory>src/main/resources</directory>-->
+        <!--<filtering>true</filtering>-->
+      <!--</resource>-->
+    <!--</resources>-->
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.55</version> <!-- or whatever the newest version available is -->
+    <version>3.56</version> <!-- or whatever the newest version available is -->
     <!--Check https://mvnrepository.com/artifact/org.jenkins-ci.plugins/plugin?repo=jenkins-releases-->
     <relativePath />
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.datadoghq</groupId>
       <artifactId>java-dogstatsd-client</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogClient.java
@@ -74,7 +74,7 @@ public interface DatadogClient {
 
     public void setPort(int port);
 
-    public void setLogCollectionPort(int logCollectionPort);
+    public void setLogCollectionPort(Integer logCollectionPort);
 
     public boolean isDefaultIntakeConnectionBroken();
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogClient.java
@@ -27,6 +27,7 @@ package org.datadog.jenkins.plugins.datadog;
 
 import com.timgroup.statsd.ServiceCheck;
 import hudson.util.Secret;
+import org.datadog.jenkins.plugins.datadog.logs.DatadogConsoleLogFilter;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
@@ -65,17 +66,29 @@ public interface DatadogClient {
 
     public void setUrl(String url);
 
+    public void setLogIntakeUrl(String logIntakeUrl);
+
     public void setApiKey(Secret apiKey);
 
     public void setHostname(String hostname);
 
     public void setPort(int port);
 
+    public void setLogCollectionPort(int logCollectionPort);
+
+    public boolean isDefaultIntakeConnectionBroken();
+
+    public void setDefaultIntakeConnectionBroken(boolean defaultIntakeConnectionBroken);
+
+    public boolean isLogIntakeConnectionBroken();
+
+    public void setLogIntakeConnectionBroken(boolean logIntakeConnectionBroken);
+
     /**
      * Sends an event to the Datadog API, including the event payload.
      *
      * @param event - a DatadogEvent object
-     * @return  a boolean to signify the success or failure of the HTTP POST request.
+     * @return a boolean to signify the success or failure of the HTTP POST request.
      */
     public boolean event(DatadogEvent event);
 
@@ -83,9 +96,9 @@ public interface DatadogClient {
      * Increment a counter for the given metrics.
      * NOTE: To submit all counters you need to execute the flushCounters method.
      * This is to aggregate counters and submit them in batch to Datadog in order to minimize network traffic.
-     * @param name - metric name
+     * @param name     - metric name
      * @param hostname - metric hostname
-     * @param tags - metric tags
+     * @param tags     - metric tags
      */
     public void incrementCounter(String name, String hostname, Map<String, Set<String>> tags);
 
@@ -109,7 +122,7 @@ public interface DatadogClient {
      * Sends a service check to the Datadog API, including the check name, and status.
      *
      * @param name     - A String with the name of the service check to record.
-     * @param status     - An Status with the status code to record for this service check.
+     * @param status   - An Status with the status code to record for this service check.
      * @param hostname - A String with the hostname to submit.
      * @param tags     - A Map containing the tags to submit.
      * @return a boolean to signify the success or failure of the HTTP POST request.
@@ -117,11 +130,11 @@ public interface DatadogClient {
     public boolean serviceCheck(String name, Status status, String hostname, Map<String, Set<String>> tags);
 
     /**
-     * Tests the apiKey is valid.
-     *
-     * @return a boolean to signify the success or failure of the HTTP GET request.
-     * @throws IOException      if there is an input/output exception.
-     * @throws ServletException if there is a servlet exception.
+     * Send log message.
+     * @param payload log payload to submit JSON object as String
+     * @return a boolean to signify the success or failure of the request.
+     * @throws IOException
      */
-    public boolean validate() throws IOException, ServletException;
+    public boolean sendLogs(String payload) throws IOException;
+
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogClient.java
@@ -133,8 +133,7 @@ public interface DatadogClient {
      * Send log message.
      * @param payload log payload to submit JSON object as String
      * @return a boolean to signify the success or failure of the request.
-     * @throws IOException
      */
-    public boolean sendLogs(String payload) throws IOException;
+    public boolean sendLogs(String payload);
 
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -53,9 +53,11 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
 
     private static String REPORT_WITH_PROPERTY = "DATADOG_JENKINS_PLUGIN_REPORT_WITH";
     private static String TARGET_API_URL_PROPERTY = "DATADOG_JENKINS_PLUGIN_TARGET_API_URL";
+    private static String TARGET_LOG_INTAKE_URL_PROPERTY = "DATADOG_JENKINS_PLUGIN_TARGET_LOG_INTAKE_URL";
     private static String TARGET_API_KEY_PROPERTY = "DATADOG_JENKINS_PLUGIN_TARGET_API_KEY";
     private static String TARGET_HOST_PROPERTY = "DATADOG_JENKINS_PLUGIN_TARGET_HOST";
     private static String TARGET_PORT_PROPERTY = "DATADOG_JENKINS_PLUGIN_TARGET_PORT";
+    private static String TARGET_LOG_COLLECTION_PORT_PROPERTY = "DATADOG_JENKINS_PLUGIN_TARGET_LOG_COLLECTION_PORT";
     private static String HOSTNAME_PROPERTY = "DATADOG_JENKINS_PLUGIN_HOSTNAME";
     private static String BLACKLIST_PROPERTY = "DATADOG_JENKINS_PLUGIN_BLACKLIST";
     private static String WHITELIST_PROPERTY = "DATADOG_JENKINS_PLUGIN_WHITELIST";
@@ -64,101 +66,140 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private static String GLOBAL_JOB_TAGS_PROPERTY = "DATADOG_JENKINS_PLUGIN_GLOBAL_JOB_TAGS";
     private static String EMIT_SECURITY_EVENTS_PROPERTY = "DATADOG_JENKINS_PLUGIN_EMIT_SECURITY_EVENTS";
     private static String EMIT_SYSTEM_EVENTS_PROPERTY = "DATADOG_JENKINS_PLUGIN_EMIT_SYSTEM_EVENTS";
+    private static String ENABLE_COLLECT_BUILD_LOGS_PROPERTY = "DATADOG_JENKINS_PLUGIN_COLLECT_BUILD_LOGS";
 
     private static String DEFAULT_REPORT_WITH_VALUE = DatadogClient.ClientType.HTTP.name();
-    private static String DEFAULT_TARGET_API_KEY_VALUE = "https://api.datadoghq.com/api/";
+    private static String DEFAULT_TARGET_API_URL_VALUE = "https://api.datadoghq.com/api/";
+    private static String DEFAULT_TARGET_LOG_INTAKE_URL_VALUE = "https://http-intake.logs.datadoghq.com/v1/input/";
     private static String DEFAULT_TARGET_HOST_VALUE = "localhost";
     private static Integer DEFAULT_TARGET_PORT_VALUE = 8125;
+    private static Integer DEFAULT_TARGET_LOG_COLLECTION_PORT_VALUE = null;
     private static boolean DEFAULT_EMIT_SECURITY_EVENTS_VALUE = true;
     private static boolean DEFAULT_EMIT_SYSTEM_EVENTS_VALUE = true;
+    private static boolean ENABLE_COLLECT_BUILD_LOGS_VALUE = false;
 
     private String reportWith = DEFAULT_REPORT_WITH_VALUE;
-    private String targetApiURL = DEFAULT_TARGET_API_KEY_VALUE;
+    private String targetApiURL = DEFAULT_TARGET_API_URL_VALUE;
+    private String targetLogIntakeURL = DEFAULT_TARGET_LOG_INTAKE_URL_VALUE;
     private Secret targetApiKey = null;
     private String targetHost = DEFAULT_TARGET_HOST_VALUE;
     private Integer targetPort = DEFAULT_TARGET_PORT_VALUE;
+    private Integer targetLogCollectionPort = DEFAULT_TARGET_LOG_COLLECTION_PORT_VALUE;
     private String hostname = null;
     private String blacklist = null;
     private String whitelist = null;
     private String globalTagFile = null;
     private String globalTags = null;
     private String globalJobTags = null;
-    private boolean emitSecurityEvents = true;
-    private boolean emitSystemEvents = true;
+    private boolean emitSecurityEvents = DEFAULT_EMIT_SECURITY_EVENTS_VALUE;
+    private boolean emitSystemEvents = DEFAULT_EMIT_SYSTEM_EVENTS_VALUE;
+    private boolean collectBuildLogs = ENABLE_COLLECT_BUILD_LOGS_VALUE;
 
     @DataBoundConstructor
     public DatadogGlobalConfiguration() {
-        load(); // load the persisted global configuration
-        loadEnvVariables(); // load environment variables
+        loadEnvVariables(); // Load environment variables
+        load(); // Load the persisted global configuration
     }
 
     private void loadEnvVariables(){
         String reportWithEnvVar = System.getenv(REPORT_WITH_PROPERTY);
-        if(StringUtils.isNotBlank(reportWithEnvVar) && DEFAULT_REPORT_WITH_VALUE.equals(this.reportWith) &&
+        if(StringUtils.isNotBlank(reportWithEnvVar) &&
                 (reportWithEnvVar.equals(DatadogClient.ClientType.HTTP.name()) ||
                         reportWithEnvVar.equals(DatadogClient.ClientType.DSD.name()))){
             this.reportWith = reportWithEnvVar;
         }
 
         String targetApiURLEnvVar = System.getenv(TARGET_API_URL_PROPERTY);
-        if(StringUtils.isNotBlank(targetApiURLEnvVar) && DEFAULT_TARGET_API_KEY_VALUE.equals(this.targetApiURL)) {
+        if(StringUtils.isNotBlank(targetApiURLEnvVar)){
             this.targetApiURL = targetApiURLEnvVar;
         }
 
+        String targetLogIntakeURLEnvVar = System.getenv(TARGET_LOG_INTAKE_URL_PROPERTY);
+        if(StringUtils.isNotBlank(targetApiURLEnvVar)){
+            this.targetLogIntakeURL = targetLogIntakeURLEnvVar;
+        }
+
         String targetApiKeyEnvVar = System.getenv(TARGET_API_KEY_PROPERTY);
-        if(StringUtils.isNotBlank(targetApiKeyEnvVar) && this.targetApiKey == null) {
+        if(StringUtils.isNotBlank(targetApiKeyEnvVar)){
             this.targetApiKey = Secret.fromString(targetApiKeyEnvVar);
         }
 
         String targetHostEnvVar = System.getenv(TARGET_HOST_PROPERTY);
-        if(StringUtils.isNotBlank(targetHostEnvVar) && DEFAULT_TARGET_HOST_VALUE.equals(this.targetHost)) {
+        if(StringUtils.isNotBlank(targetHostEnvVar)){
             this.targetHost = targetHostEnvVar;
         }
 
         String targetPortEnvVar = System.getenv(TARGET_PORT_PROPERTY);
-        if(StringUtils.isNotBlank(targetPortEnvVar) && DEFAULT_TARGET_PORT_VALUE.equals(this.targetPort)) {
+        if(StringUtils.isNotBlank(targetPortEnvVar) && StringUtils.isNumeric(targetPortEnvVar)){
             this.targetPort = Integer.valueOf(targetPortEnvVar);
         }
 
+        String targetLogCollectionPortEnvVar = System.getenv(TARGET_LOG_COLLECTION_PORT_PROPERTY);
+        if(StringUtils.isNotBlank(targetLogCollectionPortEnvVar) && StringUtils.isNumeric(targetLogCollectionPortEnvVar)){
+            this.targetLogCollectionPort = Integer.valueOf(targetLogCollectionPortEnvVar);
+        }
+
         String hostnameEnvVar = System.getenv(HOSTNAME_PROPERTY);
-        if(StringUtils.isNotBlank(hostnameEnvVar) && this.hostname == null) {
+        if(StringUtils.isNotBlank(hostnameEnvVar)){
             this.hostname = hostnameEnvVar;
         }
 
         String blacklistEnvVar = System.getenv(BLACKLIST_PROPERTY);
-        if(StringUtils.isNotBlank(blacklistEnvVar) && this.blacklist == null) {
+        if(StringUtils.isNotBlank(blacklistEnvVar)){
             this.blacklist = blacklistEnvVar;
         }
 
         String whitelistEnvVar = System.getenv(WHITELIST_PROPERTY);
-        if(StringUtils.isNotBlank(whitelistEnvVar) && this.whitelist == null) {
+        if(StringUtils.isNotBlank(whitelistEnvVar)){
             this.whitelist = whitelistEnvVar;
         }
 
         String globalTagFileEnvVar = System.getenv(GLOBAL_TAG_FILE_PROPERTY);
-        if(StringUtils.isNotBlank(globalTagFileEnvVar) && this.globalTagFile == null) {
+        if(StringUtils.isNotBlank(globalTagFileEnvVar)){
             this.globalTagFile = globalTagFileEnvVar;
         }
 
         String globalTagsEnvVar = System.getenv(GLOBAL_TAGS_PROPERTY);
-        if(StringUtils.isNotBlank(globalTagsEnvVar) && this.globalTags == null) {
+        if(StringUtils.isNotBlank(globalTagsEnvVar)){
             this.globalTags = globalTagsEnvVar;
         }
 
         String globalJobTagsEnvVar = System.getenv(GLOBAL_JOB_TAGS_PROPERTY);
-        if(StringUtils.isNotBlank(globalJobTagsEnvVar) && this.globalJobTags == null) {
+        if(StringUtils.isNotBlank(globalJobTagsEnvVar)){
             this.globalJobTags = globalJobTagsEnvVar;
         }
 
         String emitSecurityEventsEnvVar = System.getenv(EMIT_SECURITY_EVENTS_PROPERTY);
-        if(StringUtils.isNotBlank(emitSecurityEventsEnvVar) && DEFAULT_EMIT_SECURITY_EVENTS_VALUE == this.emitSecurityEvents) {
+        if(StringUtils.isNotBlank(emitSecurityEventsEnvVar)){
             this.emitSecurityEvents = Boolean.valueOf(emitSecurityEventsEnvVar);
         }
 
         String emitSystemEventsEnvVar = System.getenv(EMIT_SYSTEM_EVENTS_PROPERTY);
-        if(StringUtils.isNotBlank(emitSystemEventsEnvVar) && DEFAULT_EMIT_SYSTEM_EVENTS_VALUE == this.emitSystemEvents) {
+        if(StringUtils.isNotBlank(emitSystemEventsEnvVar)){
             this.emitSystemEvents = Boolean.valueOf(emitSystemEventsEnvVar);
         }
+
+        String collectBuildLogsEnvVar = System.getenv(ENABLE_COLLECT_BUILD_LOGS_PROPERTY);
+        if(StringUtils.isNotBlank(collectBuildLogsEnvVar)){
+            this.collectBuildLogs = Boolean.valueOf(collectBuildLogsEnvVar);
+        }
+    }
+
+    private boolean validateConnection(String apiUrl, Secret apiKey){
+        try {
+            boolean status = DatadogHttpClient.validate(apiUrl, Secret.toString(apiKey));
+            if(status){
+                return true;
+            }
+            // If a client instance exist we set the connectionBroken attribute to true.
+            DatadogClient client = DatadogHttpClient.getInstance(apiUrl, this.getTargetLogIntakeURL(), apiKey);
+            if(client != null){
+                client.setDefaultIntakeConnectionBroken(true);
+            }
+        } catch (Exception e){
+            //noop
+        }
+        return false;
     }
 
     /**
@@ -175,20 +216,11 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
      */
     public FormValidation doTestConnection(@QueryParameter("targetApiKey") final String targetApiKey)
             throws IOException, ServletException {
-        try {
-            // Instantiate the Datadog Client
-            DatadogClient client = DatadogHttpClient.getInstance(this.getTargetApiURL(), Secret.fromString(targetApiKey));
-            boolean status = client.validate();
-
-            if (status) {
-                return FormValidation.ok("Great! Your API key is valid.");
-            } else {
-                return FormValidation.error("Hmmm, your API key seems to be invalid.");
-            }
-        } catch (RuntimeException e){
+        if (validateConnection(this.getTargetApiURL(), Secret.fromString(targetApiKey))) {
+            return FormValidation.ok("Great! Your API key is valid.");
+        } else {
             return FormValidation.error("Hmmm, your API key seems to be invalid.");
         }
-
     }
 
     /**
@@ -204,8 +236,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
      * @throws IOException      if there is an input/output exception.
      * @throws ServletException if there is a servlet exception.
      */
-    public FormValidation doTestHostname(@QueryParameter("hostname") final String hostname)
-            throws IOException, ServletException {
+    public FormValidation doTestHostname(@QueryParameter("hostname") final String hostname){
         if (DatadogUtilities.isValidHostname(hostname)) {
             return FormValidation.ok("Great! Your hostname is valid.");
         } else {
@@ -214,21 +245,87 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
         }
     }
 
+    private boolean validateTargetApiURL(final String targetApiURL){
+        if(!DatadogClient.ClientType.HTTP.name().equals(reportWith)){
+            return true;
+        }
+        return StringUtils.isNotBlank(targetApiURL) && targetApiURL.contains("http");
+    }
+
     /**
      * @param targetApiURL - The API URL which the plugin will report to.
      * @return a FormValidation object used to display a message to the user on the configuration
      * screen.
      */
     public FormValidation doCheckTargetApiURL(@QueryParameter("targetApiURL") final String targetApiURL) {
-        if (!targetApiURL.contains("http")) {
+        if(!validateTargetApiURL(targetApiURL)) {
             return FormValidation.error("The field must be configured in the form <http|https>://<url>/");
         }
 
-        if (StringUtils.isBlank(targetApiURL)) {
-            return FormValidation.error("Empty API URL");
+        return FormValidation.ok("Valid URL");
+    }
+
+    private boolean validateTargetLogIntakeURL(final String targetLogIntakeURL) {
+        if(!DatadogClient.ClientType.HTTP.name().equals(reportWith) || !collectBuildLogs){
+            return true;
+        }
+        return StringUtils.isNotBlank(targetLogIntakeURL) && targetLogIntakeURL.contains("http");
+    }
+
+    /**
+     * @param targetLogIntakeURL - The Log Intake URL which the plugin will report to.
+     * @return a FormValidation object used to display a message to the user on the configuration
+     * screen.
+     */
+    public FormValidation doCheckTargetLogIntakeURL(@QueryParameter("targetLogIntakeURL") final String targetLogIntakeURL) {
+        if (!validateTargetLogIntakeURL(targetLogIntakeURL)) {
+            return FormValidation.error("The field must be configured in the form <http|https>://<url>/");
         }
 
         return FormValidation.ok("Valid URL");
+    }
+
+
+    private boolean validateTargetPort(String targetPort) {
+        if(!DatadogClient.ClientType.DSD.name().equals(reportWith)) {
+            return true;
+        }
+
+        return StringUtils.isNotBlank(targetPort) && StringUtils.isNumeric(targetPort);
+    }
+
+    /**
+     * @param targetPort - The dogStatsD Port which the plugin will report to.
+     * @return a FormValidation object used to display a message to the user on the configuration
+     * screen.
+     */
+    public FormValidation doCheckTargetPort(@QueryParameter("targetPort") final String targetPort) {
+        if (!validateTargetPort(targetPort)) {
+            return FormValidation.error("Invalid Port");
+        }
+
+        return FormValidation.ok("Valid Port");
+    }
+
+    private boolean validateTargetLogCollectionPort(String targetLogCollectionPort) {
+        if(!DatadogClient.ClientType.DSD.name().equals(reportWith) || !collectBuildLogs) {
+            return true;
+        }
+
+        return StringUtils.isNotBlank(targetLogCollectionPort) && StringUtils.isNumeric(targetLogCollectionPort);
+    }
+
+    /**
+     * @param targetLogCollectionPort - The Log Collection Port which the plugin will report to.
+     * @return a FormValidation object used to display a message to the user on the configuration
+     * screen.
+     */
+    public FormValidation doCheckTargetLogCollectionPort(@QueryParameter("targetLogCollectionPort") final String targetLogCollectionPort) {
+        if (!validateTargetLogCollectionPort(targetLogCollectionPort)) {
+            return FormValidation.error("Invalid Port");
+        }
+
+        return FormValidation.ok("Valid Port");
     }
 
     /**
@@ -264,15 +361,30 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
      */
     @Override
     public boolean configure(final StaplerRequest req, final JSONObject formData) throws FormException {
+        Boolean status = super.configure(req, formData);
         try {
-            super.configure(req, formData);
-
             // Grab apiKey and hostname
             this.setReportWith(formData.getString("reportWith"));
             this.setTargetApiURL(formData.getString("targetApiURL"));
+            this.setTargetLogIntakeURL(formData.getString("targetLogIntakeURL"));
             this.setTargetApiKey(formData.getString("targetApiKey"));
             this.setTargetHost(formData.getString("targetHost"));
-            this.setTargetPort(formData.getInt("targetPort"));
+            String portStr = formData.getString("targetPort");
+            if(StringUtils.isNotBlank(portStr)){
+                if(StringUtils.isNumeric(portStr)) {
+                    this.setTargetPort(formData.getInt("targetPort"));
+                }
+            }else{
+                this.setTargetPort(null);
+            }
+            String logCollectionPortStr = formData.getString("targetLogCollectionPort");
+            if(StringUtils.isNotBlank(logCollectionPortStr)){
+                if(StringUtils.isNumeric(logCollectionPortStr)){
+                    this.setTargetLogCollectionPort(formData.getInt("targetLogCollectionPort"));
+                }
+            }else{
+                this.setTargetLogCollectionPort(null);
+            }
             this.setHostname(formData.getString("hostname"));
             this.setBlacklist(formData.getString("blacklist"));
             this.setWhitelist(formData.getString("whitelist"));
@@ -281,18 +393,47 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
             this.setGlobalJobTags(formData.getString("globalJobTags"));
             this.setEmitSecurityEvents(formData.getBoolean("emitSecurityEvents"));
             this.setEmitSystemEvents(formData.getBoolean("emitSystemEvents"));
+            this.setCollectBuildLogs(formData.getBoolean("collectBuildLogs"));
+
+            // Run connection validation if applicable
+            if(DatadogClient.ClientType.HTTP.name().equals(this.getReportWith()) && (
+                    !validateTargetApiURL(this.getTargetApiURL()) ||
+                    !validateConnection(this.getTargetApiURL(), this.getTargetApiKey()))){
+                return false;
+            }
+
+            // Run Field Validations
+            if(!validateTargetLogIntakeURL(this.getTargetLogIntakeURL()) ||
+                    !validateTargetPort(portStr) ||
+                    !validateTargetLogCollectionPort(logCollectionPortStr) ||
+                    (
+                            StringUtils.isNotBlank(this.getHostname()) &&
+                            !DatadogUtilities.isValidHostname(this.getHostname()))
+                    ){
+                return false;
+            }
 
             // Persist global configuration information
+            // Note that there is an edge case.
+            // If a client connection validation fails, the http client singleton will be updated anyway (malformed URL)
+            // even though the config is not saved below because of previous return statements.
             save();
 
-            //When form is saved...reinitialize the DatadogClient.
-            ClientFactory.getClient(DatadogClient.ClientType.valueOf(this.getReportWith()),
-                    this.getTargetApiURL(), this.getTargetApiKey(), this.getTargetHost(), this.getTargetPort());
-
-        } catch(Exception e){
+            //When form is saved....
+            DatadogClient client = ClientFactory.getClient(DatadogClient.ClientType.valueOf(this.getReportWith()),
+                    this.getTargetApiURL(), this.getTargetLogIntakeURL(), this.getTargetApiKey(), this.getTargetHost(),
+                    this.getTargetPort(), this.getTargetLogCollectionPort());
+            // ...reinitialize the DatadogClient
+            if(client != null) {
+                // There are no reasons at this point client should be null.
+                client.setDefaultIntakeConnectionBroken(false);
+                client.setLogIntakeConnectionBroken(false);
+            }
+            return status;
+        }catch(Exception e){
             DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            return false;
         }
-        return super.configure(req, formData);
     }
 
     public boolean reportWithEquals(String value){
@@ -319,9 +460,9 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     }
 
     /**
-     * Getter function for the targetApiUR global configuration.
+     * Getter function for the targetApiURL global configuration.
      *
-     * @return a String containing the targetApiUR global configuration.
+     * @return a String containing the targetApiURL global configuration.
      */
     public String getTargetApiURL() {
         return targetApiURL;
@@ -335,6 +476,25 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     @DataBoundSetter
     public void setTargetApiURL(String targetApiURL) {
         this.targetApiURL = targetApiURL;
+    }
+
+    /**
+     * Setter function for the targetLogIntakeURL global configuration.
+     *
+     * @param targetLogIntakeURL = A string containing the DataDog Log Intake URL
+     */
+    @DataBoundSetter
+    public void setTargetLogIntakeURL(String targetLogIntakeURL) {
+        this.targetLogIntakeURL = targetLogIntakeURL;
+    }
+
+    /**
+     * Getter function for the targetLogIntakeURL global configuration.
+     *
+     * @return a String containing the targetLogIntakeURL global configuration.
+     */
+    public String getTargetLogIntakeURL() {
+        return targetLogIntakeURL;
     }
 
     /**
@@ -393,6 +553,25 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     @DataBoundSetter
     public void setTargetPort(Integer targetPort) {
         this.targetPort = targetPort;
+    }
+
+    /**
+     * Getter function for the targetLogCollectionPort global configuration.
+     *
+     * @return a Integer containing the targetLogCollectionPort global configuration.
+     */
+    public Integer getTargetLogCollectionPort() {
+        return targetLogCollectionPort;
+    }
+
+    /**
+     * Setter function for the targetLogCollectionPort global configuration.
+     *
+     * @param targetLogCollectionPort = A string containing the Log Collection Port
+     */
+    @DataBoundSetter
+    public void setTargetLogCollectionPort(Integer targetLogCollectionPort) {
+        this.targetLogCollectionPort = targetLogCollectionPort;
     }
 
     /**
@@ -550,6 +729,23 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     @DataBoundSetter
     public void setEmitSystemEvents(boolean emitSystemEvents) {
         this.emitSystemEvents = emitSystemEvents;
+    }
+
+    /**
+     * @return - A {@link Boolean} indicating if the user has configured Datadog to collect logs.
+     */
+    public boolean isCollectBuildLogs() {
+        return collectBuildLogs;
+    }
+
+    /**
+     * Set the checkbox in the UI, used for Jenkins data binding
+     *
+     * @param collectBuildLogs - The checkbox status (checked/unchecked)
+     */
+    @DataBoundSetter
+    public void setCollectBuildLogs(boolean collectBuildLogs) {
+        this.collectBuildLogs = collectBuildLogs;
     }
 
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -475,7 +475,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
                 throw (FormException)e;
             }
 
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
             return false;
         }
     }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -186,16 +186,6 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
         }
     }
 
-//    private boolean validateConnection(String apiUrl, Secret apiKey){
-//        try {
-//            return DatadogHttpClient.validateDefaultIntakeConnection(apiUrl, Secret.toString(apiKey));
-//
-//        } catch (Exception e){
-//            //noop
-//        }
-//        return false;
-//    }
-
     /**
      * Tests the apiKey field from the configuration screen, to check its' validity.
      * It is used in the config.jelly resource file. See method="testConnection"

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogJobProperty.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogJobProperty.java
@@ -165,7 +165,7 @@ public class DatadogJobProperty<T extends Job<?, ?>> extends JobProperty<T> {
                 }
             }
         } catch (IOException | InterruptedException | NullPointerException e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
         return s;
     }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -50,18 +50,6 @@ public class DatadogUtilities {
 
     private static final Integer MAX_HOSTNAME_LEN = 255;
 
-    public static String getJavaRuntimeVersion(){
-        return System.getProperty("java.version");
-    }
-
-    public static String getDatadogPluginVersion(){
-        return "1.0.3-SNAPSHOT";
-    }
-
-    public static String getJenkinsVersion(){
-        return Jenkins.VERSION;
-    }
-
     /**
      * @return - The descriptor for the Datadog plugin. In this case the global configuration.
      */

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -78,10 +78,10 @@ public class DatadogUtilities {
      * Builds extraTags if any are configured in the Job.
      *
      * @param run      - Current build
-     * @param listener - Current listener
+     * @param envVars  - Environment Variables
      * @return A {@link HashMap} containing the key,value pairs of tags if any.
      */
-    public static Map<String, Set<String>> getBuildTags(Run run, @Nonnull TaskListener listener) {
+    public static Map<String, Set<String>> getBuildTags(Run run, EnvVars envVars) {
         Map<String, Set<String>> result = new HashMap<>();
         if(run == null){
             return result;
@@ -110,15 +110,10 @@ public class DatadogUtilities {
         if(workspaceTagFile == null){
             workspaceTagFile = datadogGlobalConfig.getGlobalTagFile();
         }
-        try {
-            final EnvVars envVars = run.getEnvironment(listener);
-            if (workspaceTagFile != null) {
-                result = TagsUtil.merge(result, computeTagListFromVarList(envVars, workspaceTagFile));
-            }
-            result = TagsUtil.merge(result, computeTagListFromVarList(envVars, tagProperties));
-        } catch (IOException | InterruptedException e) {
-            severe(logger, e, null);
+        if (workspaceTagFile != null) {
+            result = TagsUtil.merge(result, computeTagListFromVarList(envVars, workspaceTagFile));
         }
+        result = TagsUtil.merge(result, computeTagListFromVarList(envVars, tagProperties));
 
         result = TagsUtil.merge(result, getTagsFromGlobalJobTags(jobName, globalJobTags));
         return result;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -50,6 +50,18 @@ public class DatadogUtilities {
 
     private static final Integer MAX_HOSTNAME_LEN = 255;
 
+    public static String getJavaRuntimeVersion(){
+        return System.getProperty("java.version");
+    }
+
+    public static String getDatadogPluginVersion(){
+        return "1.0.3-SNAPSHOT";
+    }
+
+    public static String getJenkinsVersion(){
+        return Jenkins.VERSION;
+    }
+
     /**
      * @return - The descriptor for the Datadog plugin. In this case the global configuration.
      */

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -31,6 +31,7 @@ import hudson.XmlFile;
 import hudson.model.*;
 import hudson.model.labels.LabelAtom;
 import jenkins.model.Jenkins;
+import org.datadog.jenkins.plugins.datadog.util.SuppressFBWarnings;
 import org.datadog.jenkins.plugins.datadog.util.TagsUtil;
 
 import javax.annotation.Nonnull;
@@ -566,10 +567,18 @@ public class DatadogUtilities {
         }
     }
 
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
     public static void severe(Logger logger, Throwable e, String message){
-        message = (message == null) ? "" : message;
-        StringWriter sw = new StringWriter();
-        e.printStackTrace(new PrintWriter(sw));
-        logger.severe(message + sw.toString());
+        if(message == null){
+            message = e != null ? "An unexpected error occurred": "";
+        }
+        if(!message.isEmpty()) {
+            logger.severe(message);
+        }
+        if(e != null) {
+            StringWriter sw = new StringWriter();
+            e.printStackTrace(new PrintWriter(sw));
+            logger.finer(message + ": " + sw.toString());
+        }
     }
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/ClientFactory.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/ClientFactory.java
@@ -32,12 +32,13 @@ import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
 
 public class ClientFactory {
 
-    public static DatadogClient getClient(DatadogClient.ClientType type, String apiUrl, Secret apiKey, String host, Integer port){
+    public static DatadogClient getClient(DatadogClient.ClientType type, String apiUrl, String logIntakeUrl,
+                                          Secret apiKey, String host, Integer port, Integer logCollectionPort){
         switch(type){
             case HTTP:
-                return DatadogHttpClient.getInstance(apiUrl, apiKey);
+                return DatadogHttpClient.getInstance(apiUrl, logIntakeUrl, apiKey);
             case DSD:
-                return DogStatsDClient.getInstance(host, port);
+                return DogStatsDClient.getInstance(host, port, logCollectionPort);
             default:
                 return null;
         }
@@ -47,17 +48,21 @@ public class ClientFactory {
         DatadogGlobalConfiguration descriptor = DatadogUtilities.getDatadogGlobalDescriptor();
         String reportWith = null;
         String targetApiURL = null;
+        String targetLogIntakeURL = null;
         Secret targetApiKey = null;
         String targetHost = null;
         Integer targetPort = null;
+        Integer targetLogCollectionPort = null;
         if(descriptor != null){
             reportWith = descriptor.getReportWith();
             targetApiURL = descriptor.getTargetApiURL();
+            targetLogIntakeURL = descriptor.getTargetLogIntakeURL();
             targetApiKey = descriptor.getTargetApiKey();
             targetHost = descriptor.getTargetHost();
             targetPort = descriptor.getTargetPort();
+            targetLogCollectionPort = descriptor.getTargetLogCollectionPort();
         }
-        return ClientFactory.getClient(DatadogClient.ClientType.valueOf(reportWith),
-                targetApiURL, targetApiKey, targetHost, targetPort);
+        return ClientFactory.getClient(DatadogClient.ClientType.valueOf(reportWith), targetApiURL, targetLogIntakeURL,
+                targetApiKey, targetHost, targetPort, targetLogCollectionPort);
     }
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogErrorManager.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogErrorManager.java
@@ -1,0 +1,33 @@
+package org.datadog.jenkins.plugins.datadog.clients;
+
+import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
+
+import java.util.logging.ErrorManager;
+import java.util.logging.Logger;
+
+public class DatadogErrorManager extends ErrorManager {
+
+    private static final Logger logger = Logger.getLogger(DatadogErrorManager.class.getName());
+
+    private boolean reported = false;
+
+    public synchronized void error(String msg, Exception ex, int code) {
+        if (reported) {
+            // We only report the first error, to avoid clogging
+            // the screen.
+            return;
+        }
+        reported = true;
+        String text = "java.util.logging.ErrorManager: " + code;
+        if (msg != null) {
+            text = text + ": " + msg;
+        }
+        DatadogUtilities.severe(logger, ex, text);
+
+    }
+
+    public boolean hadReportedIssue(){
+        return reported;
+    }
+
+}

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogFormatter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogFormatter.java
@@ -1,0 +1,14 @@
+package org.datadog.jenkins.plugins.datadog.clients;
+
+import java.util.logging.LogRecord;
+import java.util.logging.SimpleFormatter;
+
+public class DatadogFormatter extends SimpleFormatter {
+    private static final String format = "%1$s %n";
+
+    @Override
+    public synchronized String format(LogRecord lr) {
+        return String.format(format, lr.getMessage());
+    }
+
+}

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
@@ -421,6 +421,10 @@ public class DatadogHttpClient implements DatadogClient {
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setRequestProperty("DD-API-KEY", Secret.toString(apiKey));
+            conn.setRequestProperty("User-Agent", String.format("Datadog/%s/jenkins Java/%s Jenkins/%s",
+                    DatadogUtilities.getDatadogPluginVersion(),
+                    DatadogUtilities.getJavaRuntimeVersion(),
+                    DatadogUtilities.getJenkinsVersion()));
             conn.setUseCaches(false);
             conn.setDoInput(true);
             conn.setDoOutput(true);
@@ -549,7 +553,7 @@ public class DatadogHttpClient implements DatadogClient {
     }
 
     public static boolean validateLogIntakeConnection(String url, Secret apiKey) throws IOException {
-        return postLogs(url, apiKey, "{\"message\":\"[datadog-plugin] Check connection\", \"ddsource\":\"Jenkins\", \"service\":\"Jenkins\", \"hostname\":"+DatadogUtilities.getHostname(null)+"}");
+        return postLogs(url, apiKey, "{\"message\":\"[datadog-plugin] Check connection\", \"ddsource\":\"Jenkins\", \"service\":\"Jenkins\", \"hostname\":\""+DatadogUtilities.getHostname(null)+"\"}");
     }
 
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
@@ -153,7 +153,7 @@ public class DatadogHttpClient implements DatadogClient {
     }
 
     @Override
-    public void setLogCollectionPort(int logCollectionPort) {
+    public void setLogCollectionPort(Integer logCollectionPort) {
         // noop
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
@@ -106,7 +106,7 @@ public class DatadogHttpClient implements DatadogClient {
 
         // We reset params just in case we change values
         // Note that we don't validate the connection at this point.
-        // Run validate to test teh connection instead.
+        // Run validate to test the connection instead.
         instance.setApiKey(apiKey);
         instance.setUrl(url);
         instance.setLogIntakeUrl(logIntakeUrl);
@@ -126,6 +126,10 @@ public class DatadogHttpClient implements DatadogClient {
     @Override
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public String getLogIntakeUrl() {
+        return logIntakeUrl;
     }
 
     @Override
@@ -179,10 +183,10 @@ public class DatadogHttpClient implements DatadogClient {
 
     public boolean event(DatadogEvent event) {
         logger.fine("Sending event");
-        boolean status = false;
-        if(this.defaultIntakeConnectionBroken){
+        boolean status;
+        if(this.isDefaultIntakeConnectionBroken()){
             logger.severe("Your client is not initialized properly");
-            return status;
+            return false;
         }
 
         try {
@@ -206,7 +210,7 @@ public class DatadogHttpClient implements DatadogClient {
 
     @Override
     public void incrementCounter(String name, String hostname, Map<String, Set<String>> tags) {
-        if(this.defaultIntakeConnectionBroken){
+        if(this.isDefaultIntakeConnectionBroken()){
             logger.severe("Your client is not initialized properly");
             return;
         }
@@ -219,7 +223,7 @@ public class DatadogHttpClient implements DatadogClient {
 
         logger.fine("Run flushCounters method");
         // Submit all metrics as gauge
-        for (final Iterator<Map.Entry<CounterMetric, Integer>> iter = counters.entrySet().iterator(); iter.hasNext();){
+        for(final Iterator<Map.Entry<CounterMetric, Integer>> iter = counters.entrySet().iterator(); iter.hasNext();){
             Map.Entry<CounterMetric, Integer> entry = iter.next();
             CounterMetric counterMetric = entry.getKey();
             int count = entry.getValue();
@@ -237,7 +241,7 @@ public class DatadogHttpClient implements DatadogClient {
     }
 
     private boolean postMetric(String name, float value, String hostname, Map<String, Set<String>> tags, String type) {
-        if(this.defaultIntakeConnectionBroken){
+        if(this.isDefaultIntakeConnectionBroken()){
             logger.severe("Your client is not initialized properly");
             return false;
         }
@@ -306,6 +310,7 @@ public class DatadogHttpClient implements DatadogClient {
             logger.fine(tags.toString());
             payload.put("tags", TagsUtil.convertTagsToJSONArray(tags));
         }
+
         return post(payload, SERVICECHECK);
     }
 
@@ -319,20 +324,18 @@ public class DatadogHttpClient implements DatadogClient {
      * @throws IOException if HttpURLConnection fails to open connection
      */
     private boolean post(final JSONObject payload, final String type) {
-        if(this.defaultIntakeConnectionBroken){
+        if(this.isDefaultIntakeConnectionBroken()){
             logger.severe("Your client is not initialized properly");
             return false;
         }
 
-        String urlParameters = "?api_key=" + Secret.toString(apiKey);
+        String urlParameters = "?api_key=" + Secret.toString(this.getApiKey());
         HttpURLConnection conn = null;
         boolean status = true;
 
         try {
-            logger.finer("Setting up HttpURLConnection...");
-            conn = getHttpURLConnection(new URL(url
-                    + type
-                    + urlParameters));
+            logger.fine("Setting up HttpURLConnection...");
+            conn = getHttpURLConnection(new URL(this.getUrl() + type + urlParameters));
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setUseCaches(false);
@@ -340,7 +343,7 @@ public class DatadogHttpClient implements DatadogClient {
             conn.setDoOutput(true);
 
             OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream(), "utf-8");
-            logger.finer("Writing to OutputStreamWriter...");
+            logger.fine("Writing to OutputStreamWriter...");
             wr.write(payload.toString());
             wr.close();
 
@@ -381,14 +384,51 @@ public class DatadogHttpClient implements DatadogClient {
         return status;
     }
 
-    public static boolean validate(String apiUrl, String apiKey) throws IOException {
-        String urlParameters = "?api_key=" + apiKey;
+    /**
+     * Posts a given {@link JSONObject} payload to the Datadog API, using the
+     * user configured apiKey.
+     *
+     * @param payload - A JSONObject containing a specific subset of a builds metadata.
+     * @return a boolean to signify the success or failure of the HTTP POST request.
+     * @throws IOException if HttpURLConnection fails to open connection
+     */
+    public boolean sendLogs(String payload) throws IOException {
+        if(this.isLogIntakeConnectionBroken()){
+            logger.severe("Your client is not initialized properly");
+            return false;
+        }
+
+        if(this.getLogIntakeUrl() == null || this.getLogIntakeUrl().isEmpty()){
+            logger.severe("Datadog Log Intake URL is not set properly");
+            throw new RuntimeException("Datadog Log Collection Port not set properly");
+        }
+
+        return postLogs(this.getLogIntakeUrl(), getApiKey(), payload);
+    }
+
+    private static boolean postLogs(String url, Secret apiKey, String payload) throws IOException {
+        if(payload == null){
+            logger.fine("No payload to post");
+            return true;
+        }
+
         HttpURLConnection conn = null;
-        boolean status = true;
+        URL logsEndpointURL = new URL(url);
+
         try {
-            // Make request
-            conn = getHttpURLConnection(new URL(apiUrl + VALIDATE + urlParameters));
-            conn.setRequestMethod("GET");
+            logger.fine("Setting up HttpURLConnection...");
+            conn = getHttpURLConnection(logsEndpointURL);
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("DD-API-KEY", Secret.toString(apiKey));
+            conn.setUseCaches(false);
+            conn.setDoInput(true);
+            conn.setDoOutput(true);
+
+            OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream(), "utf-8");
+            logger.fine("Writing to OutputStreamWriter...");
+            wr.write(payload);
+            wr.close();
 
             // Get response
             BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), "utf-8"));
@@ -399,25 +439,31 @@ public class DatadogHttpClient implements DatadogClient {
             }
             rd.close();
 
-            // Validate
-            JSONObject json = (JSONObject) JSONSerializer.toJSON(result.toString());
-            if (!json.getBoolean("valid")) {
-                status = false;
+            if ("{}".equals(result.toString())) {
+                logger.fine(String.format("Logs API call was sent successfully!"));
+                logger.fine(String.format("Payload: %s", payload));
+            } else {
+                logger.severe(String.format("Logs API call failed!"));
+                logger.severe(String.format("Payload: %s", payload));
+                return false;
             }
         } catch (Exception e) {
-            if (conn != null && conn.getResponseCode() == HTTP_FORBIDDEN) {
-                logger.severe("Hmmm, your API key may be invalid. We received a 403 error.");
-                DatadogUtilities.severe(logger, e, null);
-            } else {
-                DatadogUtilities.severe(logger, e, "Client error: ");
+            try {
+                if (conn != null && conn.getResponseCode() == BAD_REQUEST) {
+                    logger.severe("Hmmm, your API key or your Log Intake URL may be invalid. We received a 400 in response.");
+                } else {
+                    DatadogUtilities.severe(logger, e, "Client error: ");
+                }
+            } catch (IOException ex) {
+                DatadogUtilities.severe(logger, ex, null);
             }
-            status = false;
+            return false;
         } finally {
             if (conn != null) {
                 conn.disconnect();
             }
         }
-        return status;
+        return true;
     }
 
     /**
@@ -464,42 +510,14 @@ public class DatadogHttpClient implements DatadogClient {
         return conn;
     }
 
-    /**
-     * Posts a given {@link JSONObject} payload to the Datadog API, using the
-     * user configured apiKey.
-     *
-     * @param payload - A JSONObject containing a specific subset of a builds metadata.
-     * @return a boolean to signify the success or failure of the HTTP POST request.
-     * @throws IOException if HttpURLConnection fails to open connection
-     */
-    public boolean sendLogs(String payload) throws IOException {
-        if(this.logIntakeConnectionBroken){
-            logger.severe("Your client is not initialized properly");
-            return false;
-        }
-
-        if(logIntakeUrl == null || logIntakeUrl.isEmpty()){
-            logger.severe("Datadog Log Intake URL is not set properly");
-            throw new RuntimeException("Datadog Log Collection Port not set properly");
-        }
-
+    public static boolean validateDefaultIntakeConnection(String url, Secret apiKey) throws IOException {
+        String urlParameters = "?api_key=" + Secret.toString(apiKey);
         HttpURLConnection conn = null;
-        URL logsEndpointURL = new URL(logIntakeUrl);
-
+        boolean status = true;
         try {
-            logger.finer("Setting up HttpURLConnection...");
-            conn = getHttpURLConnection(logsEndpointURL);
-            conn.setRequestMethod("POST");
-            conn.setRequestProperty("Content-Type", "application/json");
-            conn.setRequestProperty("DD-API-KEY", Secret.toString(apiKey));
-            conn.setUseCaches(false);
-            conn.setDoInput(true);
-            conn.setDoOutput(true);
-
-            OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream(), "utf-8");
-            logger.finer("Writing to OutputStreamWriter...");
-            wr.write(payload);
-            wr.close();
+            // Make request
+            conn = getHttpURLConnection(new URL(url + VALIDATE + urlParameters));
+            conn.setRequestMethod("GET");
 
             // Get response
             BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), "utf-8"));
@@ -510,34 +528,28 @@ public class DatadogHttpClient implements DatadogClient {
             }
             rd.close();
 
-            if ("{}".equals(result.toString())) {
-                logger.fine(String.format("Logs API call was sent successfully!"));
-                logger.fine(String.format("Payload: %s", payload.toString()));
-            } else {
-                logger.severe(String.format("Logs API call failed!"));
-                logger.severe(String.format("Payload: %s", payload.toString()));
-                this.logIntakeConnectionBroken = true;
+            // Validate
+            JSONObject json = (JSONObject) JSONSerializer.toJSON(result.toString());
+            if (!json.getBoolean("valid")) {
+                status = false;
             }
-
         } catch (Exception e) {
-            try {
-                if (conn != null && conn.getResponseCode() == BAD_REQUEST) {
-                    logger.severe("Hmmm, your API key or your Log Intake URL may be invalid. We received a 400 in response.");
-                    DatadogUtilities.severe(logger, e, null);
-                } else {
-                    DatadogUtilities.severe(logger, e, "Client error: ");
-                }
-            } catch (IOException ex) {
-                logger.fine(ex.toString());
-                throw ex;
+            if (conn != null && conn.getResponseCode() == HTTP_FORBIDDEN) {
+                logger.severe("Hmmm, your API key may be invalid. We received a 403 error.");
+            } else {
+                DatadogUtilities.severe(logger, e, "Client error: ");
             }
-            this.logIntakeConnectionBroken = true;
+            status = false;
         } finally {
             if (conn != null) {
                 conn.disconnect();
             }
         }
-        return !this.logIntakeConnectionBroken;
+        return status;
+    }
+
+    public static boolean validateLogIntakeConnection(String url, Secret apiKey) throws IOException {
+        return postLogs(url, apiKey, "{\"message\":\"[datadog-plugin] Check connection\", \"ddsource\":\"Jenkins\", \"service\":\"Jenkins\"}");
     }
 
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
@@ -370,7 +370,7 @@ public class DatadogHttpClient implements DatadogClient {
                     logger.severe("Hmmm, your API key may be invalid. We received a 403 error.");
                     DatadogUtilities.severe(logger, e, null);
                 } else {
-                    DatadogUtilities.severe(logger, e, "Client error: ");
+                    DatadogUtilities.severe(logger, e, "Client error");
                 }
             } catch (IOException ex) {
                 DatadogUtilities.severe(logger, e, null);
@@ -452,7 +452,7 @@ public class DatadogHttpClient implements DatadogClient {
                 if (conn != null && conn.getResponseCode() == BAD_REQUEST) {
                     logger.severe("Hmmm, your API key or your Log Intake URL may be invalid. We received a 400 in response.");
                 } else {
-                    DatadogUtilities.severe(logger, e, "Client error: ");
+                    DatadogUtilities.severe(logger, e, "Client error");
                 }
             } catch (IOException ex) {
                 DatadogUtilities.severe(logger, ex, null);
@@ -537,7 +537,7 @@ public class DatadogHttpClient implements DatadogClient {
             if (conn != null && conn.getResponseCode() == HTTP_FORBIDDEN) {
                 logger.severe("Hmmm, your API key may be invalid. We received a 403 error.");
             } else {
-                DatadogUtilities.severe(logger, e, "Client error: ");
+                DatadogUtilities.severe(logger, e, "Client error");
             }
             status = false;
         } finally {
@@ -549,7 +549,7 @@ public class DatadogHttpClient implements DatadogClient {
     }
 
     public static boolean validateLogIntakeConnection(String url, Secret apiKey) throws IOException {
-        return postLogs(url, apiKey, "{\"message\":\"[datadog-plugin] Check connection\", \"ddsource\":\"Jenkins\", \"service\":\"Jenkins\"}");
+        return postLogs(url, apiKey, "{\"message\":\"[datadog-plugin] Check connection\", \"ddsource\":\"Jenkins\", \"service\":\"Jenkins\", \"hostname\":"+DatadogUtilities.getHostname(null)+"}");
     }
 
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
@@ -53,8 +53,8 @@ public class DogStatsDClient implements DatadogClient {
 
     private StatsDClient statsd;
     private String hostname;
-    private int port = -1;
-    private Integer logCollectionPort = -1;
+    private Integer port = null;
+    private Integer logCollectionPort = null;
     private boolean isStopped = true;
 
     /**
@@ -71,6 +71,13 @@ public class DogStatsDClient implements DatadogClient {
             if (hostname == null || hostname.isEmpty()) {
                 logger.severe("Datadog Target URL is not set properly");
                 return null;
+            }
+            if (port == null) {
+                logger.severe("Datadog Target Port is not set properly");
+                return null;
+            }
+            if (logCollectionPort == null) {
+                logger.warning("Datadog Log Collection Port is not set properly");
             }
         }
 
@@ -274,7 +281,7 @@ public class DogStatsDClient implements DatadogClient {
 
     @Override
     public boolean sendLogs(String payload) throws IOException {
-        if(logCollectionPort == -1){
+        if(logCollectionPort == null){
             logger.severe("Datadog Log Collection Port is not set properly");
             throw new RuntimeException("Datadog Log Collection Port not set properly");
         }
@@ -297,11 +304,11 @@ public class DogStatsDClient implements DatadogClient {
 
             if ("{}".equals(result.toString())) {
                 logger.fine(String.format("Logs API call was sent successfully!"));
-                logger.fine(String.format("Payload: %s", payload.toString()));
+                logger.fine(String.format("Payload: %s", payload));
                 return true;
             } else {
                 logger.severe(String.format("Logs API call failed!"));
-                logger.severe(String.format("Payload: %s", payload.toString()));
+                logger.severe(String.format("Payload: %s", payload));
                 return false;
             }
         } catch (IOException e) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
@@ -34,10 +34,9 @@ import org.datadog.jenkins.plugins.datadog.util.SuppressFBWarnings;
 import org.datadog.jenkins.plugins.datadog.util.TagsUtil;
 
 import java.io.*;
-import java.net.Socket;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Logger;
+import java.util.logging.*;
 
 /**
  * This class is used to collect all methods that has to do with transmitting
@@ -46,12 +45,16 @@ import java.util.logging.Logger;
 public class DogStatsDClient implements DatadogClient {
 
     private static DatadogClient instance;
+
     private static final Logger logger = Logger.getLogger(DogStatsDClient.class.getName());
 
     @SuppressFBWarnings(value="MS_SHOULD_BE_FINAL")
     public static boolean enableValidations = true;
 
     private StatsDClient statsd;
+    private Logger ddLogger;
+    private String previousPayload;
+
     private String hostname;
     private Integer port = null;
     private Integer logCollectionPort = null;
@@ -96,7 +99,11 @@ public class DogStatsDClient implements DatadogClient {
             instance.setPort(port);
             ((DogStatsDClient)instance).reinitialize(true);
         }
-        instance.setLogCollectionPort(logCollectionPort);
+        if(!hostname.equals(((DogStatsDClient)instance).getHostname()) ||
+                !logCollectionPort.equals(((DogStatsDClient) instance).getLogCollectionPort())) {
+            instance.setLogCollectionPort(logCollectionPort);
+            ((DogStatsDClient)instance).reinitializeLogger(true);
+        }
         return instance;
     }
 
@@ -106,10 +113,11 @@ public class DogStatsDClient implements DatadogClient {
         this.logCollectionPort = logCollectionPort;
 
         reinitialize(true);
+        reinitializeLogger(true);
     }
 
     /**
-     * reinitialize the dogStasDClient
+     * reinitialize the dogStatsD Client
      * @param force - force to reinitialize
      * @return true if reinitialized properly otherwise false
      */
@@ -119,14 +127,44 @@ public class DogStatsDClient implements DatadogClient {
                 return true;
             }
             this.stop();
-            logger.severe("Re/Initialize DogStatsD Client: hostname: " + this.hostname + " port = " + this.port);
+            logger.info("Re/Initialize DogStatsD Client: hostname = " + this.hostname + ", port = " + this.port);
             this.statsd = new NonBlockingStatsDClient(null, this.hostname, this.port);
             this.isStopped = false;
         } catch (Exception e){
-            DatadogUtilities.severe(logger, e, "Failed to reinitialize DogStatsD Client: ");
+            DatadogUtilities.severe(logger, e, "Failed to reinitialize DogStatsD Client");
             this.stop();
         }
         return !isStopped;
+    }
+
+    /**
+     * reinitialize the Logger Client
+     * @param force - force to reinitialize
+     * @return true if reinitialized properly otherwise false
+     */
+    private boolean reinitializeLogger(boolean force) {
+        if(this.ddLogger != null && !force){
+            return true;
+        }
+        try {
+            logger.info("Re/Initialize Datadog-Plugin Logger: hostname = " + this.hostname + ", logCollectionPort = " + this.logCollectionPort);
+            this.ddLogger = Logger.getLogger("Datadog-Plugin Logger");
+            this.ddLogger.setUseParentHandlers(false);
+            //Remove all existing Handlers
+            Handler[] handlers = this.ddLogger.getHandlers();
+            for(Handler h : handlers){
+                this.ddLogger.removeHandler(h);
+            }
+            //Add New Handler
+            SocketHandler socketHandler = new SocketHandler(hostname, logCollectionPort);
+            socketHandler.setFormatter(new DatadogFormatter());
+            socketHandler.setErrorManager(new DatadogErrorManager());
+            this.ddLogger.addHandler(socketHandler);
+        } catch (Exception e){
+            DatadogUtilities.severe(logger, e, "Failed to reinitialize Datadog-Plugin Logger");
+            return false;
+        }
+        return true;
     }
 
     private boolean stop(){
@@ -134,7 +172,7 @@ public class DogStatsDClient implements DatadogClient {
             try{
                 this.statsd.stop();
             }catch(Exception e){
-                DatadogUtilities.severe(logger, e, "Failed to stop DogStatsD Client: ");
+                DatadogUtilities.severe(logger, e, "Failed to stop DogStatsD Client");
                 return false;
             }
             this.statsd = null;
@@ -222,7 +260,7 @@ public class DogStatsDClient implements DatadogClient {
             this.statsd.recordEvent(ev, TagsUtil.convertTagsToArray(event.getTags()));
             return true;
         } catch(Exception e){
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
             reinitialize(true);
             return false;
         }
@@ -235,7 +273,7 @@ public class DogStatsDClient implements DatadogClient {
             logger.fine("increment counter with dogStatD client");
             this.statsd.incrementCounter(name, TagsUtil.convertTagsToArray(tags));
         } catch(Exception e){
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
             reinitialize(true);
         }
     }
@@ -253,7 +291,7 @@ public class DogStatsDClient implements DatadogClient {
             this.statsd.gauge(name, value, TagsUtil.convertTagsToArray(tags));
             return true;
         } catch(Exception e){
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
             reinitialize(true);
             return false;
         }
@@ -273,7 +311,7 @@ public class DogStatsDClient implements DatadogClient {
             this.statsd.serviceCheck(sc);
             return true;
         } catch(Exception e){
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
             reinitialize(true);
             return false;
         }
@@ -286,37 +324,37 @@ public class DogStatsDClient implements DatadogClient {
             throw new RuntimeException("Datadog Log Collection Port not set properly");
         }
 
-        try (Socket socket = new Socket(hostname, logCollectionPort)) {
-
-            OutputStream output = socket.getOutputStream();
-            OutputStreamWriter writer = new OutputStreamWriter(output, "utf-8");
-            writer.write(payload);
-
-            InputStream input = socket.getInputStream();
-
-            BufferedReader reader = new BufferedReader(new InputStreamReader(input, "utf-8"));
-            StringBuilder result = new StringBuilder();
-            String line;
-            while ((line = reader.readLine()) != null) {
-                result.append(line);
-            }
-            reader.close();
-
-            if ("{}".equals(result.toString())) {
-                logger.fine(String.format("Logs API call was sent successfully!"));
-                logger.fine(String.format("Payload: %s", payload));
-                return true;
-            } else {
-                logger.severe(String.format("Logs API call failed!"));
-                logger.severe(String.format("Payload: %s", payload));
+        if(this.ddLogger == null) {
+            boolean status = reinitializeLogger(true);
+            if(!status) {
                 return false;
             }
-        } catch (IOException e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
-            reinitialize(true);
-            return false;
         }
 
+        try {
+            this.ddLogger.info(payload);
+
+            // We check for errors in our custom errorManager
+            Handler handler = this.ddLogger.getHandlers()[0];
+            DatadogErrorManager errorManager = (DatadogErrorManager)handler.getErrorManager();
+            if(errorManager.hadReportedIssue()){
+                reinitializeLogger(true);
+                // NOTE: After a socket timeout, the first message to be sent get lost, it is only the second message
+                // that gets reported as an error in the errorManager.
+                // For this reason, we always keep the previousPayload in order to resubmit it.
+                this.ddLogger.info(previousPayload);
+                previousPayload = payload;
+                // we return false so that we retry to send the current payload message that still didn't get submitted.
+                return false;
+            }
+            previousPayload = payload;
+        }catch(Exception e){
+            DatadogUtilities.severe(logger, e, null);
+            reinitialize(true);
+            previousPayload = payload;
+            return false;
+        }
+        return true;
     }
 
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
@@ -46,7 +46,7 @@ import java.util.logging.Logger;
 public class DogStatsDClient implements DatadogClient {
 
     private static DatadogClient instance;
-    private static final Logger logger = Logger.getLogger(DatadogHttpClient.class.getName());
+    private static final Logger logger = Logger.getLogger(DogStatsDClient.class.getName());
 
     @SuppressFBWarnings(value="MS_SHOULD_BE_FINAL")
     public static boolean enableValidations = true;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
@@ -318,7 +318,7 @@ public class DogStatsDClient implements DatadogClient {
     }
 
     @Override
-    public boolean sendLogs(String payload) throws IOException {
+    public boolean sendLogs(String payload) {
         if(logCollectionPort == null){
             logger.severe("Datadog Log Collection Port is not set properly");
             throw new RuntimeException("Datadog Log Collection Port not set properly");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
@@ -54,7 +54,7 @@ public class DogStatsDClient implements DatadogClient {
     private StatsDClient statsd;
     private String hostname;
     private int port = -1;
-    private int logCollectionPort = -1;
+    private Integer logCollectionPort = -1;
     private boolean isStopped = true;
 
     /**
@@ -154,12 +154,12 @@ public class DogStatsDClient implements DatadogClient {
         this.port = port;
     }
 
-    public int getLogCollectionPort() {
+    public Integer getLogCollectionPort() {
         return logCollectionPort;
     }
 
     @Override
-    public void setLogCollectionPort(int logCollectionPort) {
+    public void setLogCollectionPort(Integer logCollectionPort) {
         this.logCollectionPort = logCollectionPort;
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/events/AbstractDatadogBuildEvent.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/events/AbstractDatadogBuildEvent.java
@@ -37,7 +37,7 @@ public abstract class AbstractDatadogBuildEvent extends AbstractDatadogEvent {
 
     public AbstractDatadogBuildEvent(BuildData buildData) {
         this.buildData = buildData;
-        setHost(buildData.getHostname("unknown"));
+        setHost(buildData.getHostname(null));
         setAggregationKey(buildData.getJobName("unknown"));
         setDate(buildData.getEndTime(DatadogUtilities.currentTimeMillis()) / 1000);
         setTags(buildData.getTags());

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/events/AbstractDatadogBuildEvent.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/events/AbstractDatadogBuildEvent.java
@@ -37,7 +37,7 @@ public abstract class AbstractDatadogBuildEvent extends AbstractDatadogEvent {
 
     public AbstractDatadogBuildEvent(BuildData buildData) {
         this.buildData = buildData;
-        setHost(buildData.getHostname(null));
+        setHost(buildData.getHostname("unknown"));
         setAggregationKey(buildData.getJobName("unknown"));
         setDate(buildData.getEndTime(DatadogUtilities.currentTimeMillis()) / 1000);
         setTags(buildData.getTags());

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
@@ -96,7 +96,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
             Queue queue = getQueue();
             Queue.Item item = queue.getItem(run.getQueueId());
             Map<String, Set<String>> tags = buildData.getTags();
-            String hostname = buildData.getHostname("null");
+            String hostname = buildData.getHostname("unknown");
             try {
                 long waiting = (DatadogUtilities.currentTimeMillis() - item.getInQueueSince()) / 1000;
                 client.gauge("jenkins.job.waiting", waiting, hostname, tags);
@@ -110,7 +110,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
 
             logger.fine("End DatadogBuildListener#onStarted");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 
@@ -152,7 +152,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
 
             // Send a metric
             Map<String, Set<String>> tags = buildData.getTags();
-            String hostname = buildData.getHostname("null");
+            String hostname = buildData.getHostname("unknown");
             client.gauge("jenkins.job.duration", buildData.getDuration(0L) / 1000, hostname, tags);
 
             // Submit counter
@@ -196,7 +196,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
 
             logger.fine("End DatadogBuildListener#onCompleted");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 
@@ -225,7 +225,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
             }
 
             // Get the list of global tags to apply
-            String hostname = buildData.getHostname("null");
+            String hostname = buildData.getHostname("unknown");
 
             // Send an event
             DatadogEvent event = new BuildAbortedEventImpl(buildData);
@@ -237,7 +237,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
 
             logger.fine("End DatadogBuildListener#onDeleted");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
@@ -72,6 +72,9 @@ public class DatadogBuildListener extends RunListener<Run>  {
 
             // Get Datadog Client Instance
             DatadogClient client = getDatadogClient();
+            if(client == null){
+                return;
+            }
 
             // Collect Build Data
             BuildData buildData;
@@ -130,6 +133,9 @@ public class DatadogBuildListener extends RunListener<Run>  {
 
             // Get Datadog Client Instance
             DatadogClient client = getDatadogClient();
+            if(client == null){
+                return;
+            }
 
             // Collect Build Data
             BuildData buildData;
@@ -205,6 +211,9 @@ public class DatadogBuildListener extends RunListener<Run>  {
 
             // Get Datadog Client Instance
             DatadogClient client = getDatadogClient();
+            if(client == null){
+                return;
+            }
 
             // Collect Build Data
             BuildData buildData;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
@@ -96,7 +96,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
             Queue queue = getQueue();
             Queue.Item item = queue.getItem(run.getQueueId());
             Map<String, Set<String>> tags = buildData.getTags();
-            String hostname = buildData.getHostname("unknown");
+            String hostname = buildData.getHostname(null);
             try {
                 long waiting = (DatadogUtilities.currentTimeMillis() - item.getInQueueSince()) / 1000;
                 client.gauge("jenkins.job.waiting", waiting, hostname, tags);
@@ -152,7 +152,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
 
             // Send a metric
             Map<String, Set<String>> tags = buildData.getTags();
-            String hostname = buildData.getHostname("unknown");
+            String hostname = buildData.getHostname(null);
             client.gauge("jenkins.job.duration", buildData.getDuration(0L) / 1000, hostname, tags);
 
             // Submit counter
@@ -225,7 +225,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
             }
 
             // Get the list of global tags to apply
-            String hostname = buildData.getHostname("unknown");
+            String hostname = buildData.getHostname(null);
 
             // Send an event
             DatadogEvent event = new BuildAbortedEventImpl(buildData);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
@@ -96,7 +96,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
             Queue queue = getQueue();
             Queue.Item item = queue.getItem(run.getQueueId());
             Map<String, Set<String>> tags = buildData.getTags();
-            String hostname = buildData.getHostname(null);
+            String hostname = buildData.getHostname("null");
             try {
                 long waiting = (DatadogUtilities.currentTimeMillis() - item.getInQueueSince()) / 1000;
                 client.gauge("jenkins.job.waiting", waiting, hostname, tags);
@@ -152,7 +152,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
 
             // Send a metric
             Map<String, Set<String>> tags = buildData.getTags();
-            String hostname = buildData.getHostname(null);
+            String hostname = buildData.getHostname("null");
             client.gauge("jenkins.job.duration", buildData.getDuration(0L) / 1000, hostname, tags);
 
             // Submit counter
@@ -225,7 +225,7 @@ public class DatadogBuildListener extends RunListener<Run>  {
             }
 
             // Get the list of global tags to apply
-            String hostname = buildData.getHostname(null);
+            String hostname = buildData.getHostname("null");
 
             // Send an event
             DatadogEvent event = new BuildAbortedEventImpl(buildData);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogComputerListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogComputerListener.java
@@ -82,12 +82,12 @@ public class DatadogComputerListener extends ComputerListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.computer.online", hostname, tags);
 
             logger.fine("End DatadogComputerListener#onOnline");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 
@@ -116,12 +116,12 @@ public class DatadogComputerListener extends ComputerListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.computer.offline", hostname, tags);
 
             logger.fine("End DatadogComputerListener#onOffline");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 
@@ -150,12 +150,12 @@ public class DatadogComputerListener extends ComputerListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.computer.temporarily_online", hostname, tags);
 
             logger.fine("End DatadogComputerListener#onTemporarilyOnline");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 
@@ -184,12 +184,12 @@ public class DatadogComputerListener extends ComputerListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.computer.temporarily_offline", hostname, tags);
 
             logger.fine("End DatadogComputerListener#onTemporarilyOffline");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 
@@ -218,12 +218,12 @@ public class DatadogComputerListener extends ComputerListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.computer.launch_failure", hostname, tags);
 
             logger.fine("End DatadogComputerListener#onLaunchFailure");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogComputerListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogComputerListener.java
@@ -68,6 +68,9 @@ public class DatadogComputerListener extends ComputerListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of tags to apply
             Map<String, Set<String>> tags = TagsUtil.merge(
@@ -99,6 +102,9 @@ public class DatadogComputerListener extends ComputerListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of tags to apply
             Map<String, Set<String>> tags = TagsUtil.merge(
@@ -130,6 +136,9 @@ public class DatadogComputerListener extends ComputerListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of tags to apply
             Map<String, Set<String>> tags = TagsUtil.merge(
@@ -161,6 +170,9 @@ public class DatadogComputerListener extends ComputerListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of tags to apply
             Map<String, Set<String>> tags = TagsUtil.merge(
@@ -192,6 +204,9 @@ public class DatadogComputerListener extends ComputerListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of tags to apply
             Map<String, Set<String>> tags = TagsUtil.merge(

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogComputerListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogComputerListener.java
@@ -82,7 +82,7 @@ public class DatadogComputerListener extends ComputerListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.computer.online", hostname, tags);
 
             logger.fine("End DatadogComputerListener#onOnline");
@@ -116,7 +116,7 @@ public class DatadogComputerListener extends ComputerListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.computer.offline", hostname, tags);
 
             logger.fine("End DatadogComputerListener#onOffline");
@@ -150,7 +150,7 @@ public class DatadogComputerListener extends ComputerListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.computer.temporarily_online", hostname, tags);
 
             logger.fine("End DatadogComputerListener#onTemporarilyOnline");
@@ -184,7 +184,7 @@ public class DatadogComputerListener extends ComputerListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.computer.temporarily_offline", hostname, tags);
 
             logger.fine("End DatadogComputerListener#onTemporarilyOffline");
@@ -218,7 +218,7 @@ public class DatadogComputerListener extends ComputerListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.computer.launch_failure", hostname, tags);
 
             logger.fine("End DatadogComputerListener#onLaunchFailure");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogItemListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogItemListener.java
@@ -78,6 +78,9 @@ public class DatadogItemListener extends ItemListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of global tags to apply
             Map<String, Set<String>> tags = DatadogUtilities.getTagsFromGlobalTags();
@@ -107,6 +110,9 @@ public class DatadogItemListener extends ItemListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of global tags to apply
             Map<String, Set<String>> tags = DatadogUtilities.getTagsFromGlobalTags();
@@ -136,6 +142,9 @@ public class DatadogItemListener extends ItemListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of global tags to apply
             Map<String, Set<String>> tags = DatadogUtilities.getTagsFromGlobalTags();

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogItemListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogItemListener.java
@@ -90,7 +90,7 @@ public class DatadogItemListener extends ItemListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.item." + action.toLowerCase(), hostname, tags);
 
             logger.fine("End DatadogItemListener#on" + action);
@@ -122,7 +122,7 @@ public class DatadogItemListener extends ItemListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.item.copied", hostname, tags);
 
             logger.fine("End DatadogItemListener#onCopied");
@@ -154,7 +154,7 @@ public class DatadogItemListener extends ItemListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.item.location_changed", hostname, tags);
 
             logger.fine("End DatadogItemListener#onLocationChanged");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogItemListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogItemListener.java
@@ -90,12 +90,12 @@ public class DatadogItemListener extends ItemListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.item." + action.toLowerCase(), hostname, tags);
 
             logger.fine("End DatadogItemListener#on" + action);
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 
@@ -122,12 +122,12 @@ public class DatadogItemListener extends ItemListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.item.copied", hostname, tags);
 
             logger.fine("End DatadogItemListener#onCopied");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 
@@ -154,12 +154,12 @@ public class DatadogItemListener extends ItemListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.item.location_changed", hostname, tags);
 
             logger.fine("End DatadogItemListener#onLocationChanged");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSCMListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSCMListener.java
@@ -99,7 +99,7 @@ public class DatadogSCMListener extends SCMListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             Map<String, Set<String>> tags = buildData.getTags();
             client.incrementCounter("jenkins.scm.checkout", hostname, tags);
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSCMListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSCMListener.java
@@ -81,6 +81,9 @@ public class DatadogSCMListener extends SCMListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Collect Build Data
             BuildData buildData;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSCMListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSCMListener.java
@@ -99,13 +99,13 @@ public class DatadogSCMListener extends SCMListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             Map<String, Set<String>> tags = buildData.getTags();
             client.incrementCounter("jenkins.scm.checkout", hostname, tags);
 
             logger.fine("End DatadogSCMListener#onCheckout");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSaveableListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSaveableListener.java
@@ -59,6 +59,9 @@ public class DatadogSaveableListener  extends SaveableListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of global tags to apply
             Map<String, Set<String>> tags = DatadogUtilities.getTagsFromGlobalTags();

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSaveableListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSaveableListener.java
@@ -71,12 +71,12 @@ public class DatadogSaveableListener  extends SaveableListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.config.changed", hostname, tags);
 
             logger.fine("End DatadogSaveableListener#onChange");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSaveableListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSaveableListener.java
@@ -71,7 +71,7 @@ public class DatadogSaveableListener  extends SaveableListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.config.changed", hostname, tags);
 
             logger.fine("End DatadogSaveableListener#onChange");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSecurityListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSecurityListener.java
@@ -74,12 +74,12 @@ public class DatadogSecurityListener extends SecurityListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.user.authenticated", hostname, tags);
 
             logger.fine("End DatadogSecurityListener#authenticated");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 
@@ -106,12 +106,12 @@ public class DatadogSecurityListener extends SecurityListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.user.access_denied", hostname, tags);
 
             logger.fine("End DatadogSecurityListener#failedToAuthenticate");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 
@@ -148,12 +148,12 @@ public class DatadogSecurityListener extends SecurityListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.incrementCounter("jenkins.user.logout", hostname, tags);
 
             logger.fine("End DatadogSecurityListener#loggedOut");
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSecurityListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSecurityListener.java
@@ -61,6 +61,9 @@ public class DatadogSecurityListener extends SecurityListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of global tags to apply
             Map<String, Set<String>> tags = DatadogUtilities.getTagsFromGlobalTags();
@@ -91,6 +94,9 @@ public class DatadogSecurityListener extends SecurityListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of global tags to apply
             Map<String, Set<String>> tags = DatadogUtilities.getTagsFromGlobalTags();
@@ -130,6 +136,9 @@ public class DatadogSecurityListener extends SecurityListener {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
 
             // Get the list of global tags to apply
             Map<String, Set<String>> tags = DatadogUtilities.getTagsFromGlobalTags();

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSecurityListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSecurityListener.java
@@ -74,7 +74,7 @@ public class DatadogSecurityListener extends SecurityListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.user.authenticated", hostname, tags);
 
             logger.fine("End DatadogSecurityListener#authenticated");
@@ -106,7 +106,7 @@ public class DatadogSecurityListener extends SecurityListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.user.access_denied", hostname, tags);
 
             logger.fine("End DatadogSecurityListener#failedToAuthenticate");
@@ -148,7 +148,7 @@ public class DatadogSecurityListener extends SecurityListener {
             client.event(event);
 
             // Submit counter
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.incrementCounter("jenkins.user.logout", hostname, tags);
 
             logger.fine("End DatadogSecurityListener#loggedOut");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogConsoleLogFilter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogConsoleLogFilter.java
@@ -1,0 +1,80 @@
+/*
+The MIT License
+
+Copyright (c) 2015-Present Datadog, Inc <opensource@datadoghq.com>
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+ */
+
+package org.datadog.jenkins.plugins.datadog.logs;
+
+import hudson.Extension;
+import hudson.console.ConsoleLogFilter;
+import hudson.model.*;
+import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.logging.Logger;
+
+@Extension
+public class DatadogConsoleLogFilter extends ConsoleLogFilter implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(DatadogConsoleLogFilter.class.getName());
+    public transient Run<?, ?> run;
+    private static final long serialVersionUID = 1L;
+
+    public DatadogConsoleLogFilter() {
+    }
+
+    public DatadogConsoleLogFilter(Run<?, ?> run) {
+        this.run = run;
+    }
+
+    public OutputStream decorateLogger(Run build, OutputStream outputStream) throws IOException, InterruptedException {
+        if (DatadogUtilities.getDatadogGlobalDescriptor() == null ||
+                !DatadogUtilities.getDatadogGlobalDescriptor().isCollectBuildLogs()) {
+            LOGGER.fine("Log Collection disabled");
+            return outputStream;
+        }
+
+        if (build != null) {
+            DatadogWriter writer = new DatadogWriter(build, outputStream, build.getCharset());
+            return new DatadogOutputStream(outputStream, writer);
+        } else if (run != null) {
+            DatadogWriter writer = new DatadogWriter(run, outputStream, run.getCharset());
+            return new DatadogOutputStream(outputStream, writer);
+        } else {
+            return outputStream;
+        }
+    }
+
+    @Override
+    public OutputStream decorateLogger(AbstractBuild abstractBuild, OutputStream outputStream) throws IOException, InterruptedException {
+        return decorateLogger((Run) abstractBuild, outputStream);
+    }
+
+    @Override
+    public OutputStream decorateLogger(@Nonnull Computer computer, OutputStream logger) throws IOException, InterruptedException {
+        return logger;
+    }
+}

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
@@ -79,7 +79,11 @@ public class DatadogWriter {
             if(client == null){
                 return;
             }
-            client.sendLogs(payload.toString());
+            boolean status = client.sendLogs(payload.toString());
+            if(!status){
+                // we try again in case a connection has to be re-established.
+                client.sendLogs(payload.toString());
+            }
         } catch (IOException | InterruptedException e){
             String msg = "Failed to send log data. No Further logs will be sent to Datadog.";
             DatadogUtilities.severe(logger, e, msg);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
@@ -1,0 +1,97 @@
+/*
+The MIT License
+
+Copyright (c) 2015-Present Datadog, Inc <opensource@datadoghq.com>
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+ */
+
+package org.datadog.jenkins.plugins.datadog.logs;
+
+import hudson.model.Run;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.datadog.jenkins.plugins.datadog.DatadogClient;
+import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
+import org.datadog.jenkins.plugins.datadog.clients.ClientFactory;
+import org.datadog.jenkins.plugins.datadog.model.BuildData;
+import org.datadog.jenkins.plugins.datadog.util.TagsUtil;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.logging.Logger;
+
+public class DatadogWriter {
+
+    private static final Logger logger = Logger.getLogger(DatadogWriter.class.getName());
+
+    private OutputStream errorStream;
+    private Charset charset;
+    private Run<?, ?> run;
+
+    public DatadogWriter(Run<?, ?> run, OutputStream error, Charset charset) {
+        this.errorStream = error != null ? error : System.err;
+        this.charset = charset;
+        this.run = run;
+    }
+
+    public Charset getCharset() {
+        return charset;
+    }
+
+    /**
+     * Write a list of lines to the indexer as one Logstash payload.
+     */
+    public void write(String line) {
+        if (!StringUtils.isNotEmpty(line)) {
+            return;
+        }
+
+        JSONObject payload = new JSONObject();
+        try {
+            BuildData buildData = new BuildData(this.run, null);
+            payload.put("ddtags", String.join(",", TagsUtil.convertTagsToArray(buildData.getTags())));
+            payload = buildData.addLogAttributes(payload);
+            payload.put("message", line);
+            payload.put("ddsource", "jenkins");
+            payload.put("service", "jenkins");
+
+            // Get Datadog Client Instance
+            DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
+            client.sendLogs(payload.toString());
+        } catch (IOException | InterruptedException e){
+            String msg = "[datadog-plugin]: Failed to send log data.\n" +
+                    "[datadog-plugin]: No Further logs will be sent to Datadog.\n";
+            DatadogUtilities.severe(logger, e, msg);
+            try {
+                errorStream.write(msg.getBytes(charset));
+                errorStream.flush();
+            } catch (IOException ex) {
+                // This should never happen.
+                ex.printStackTrace();
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
@@ -81,8 +81,7 @@ public class DatadogWriter {
             }
             client.sendLogs(payload.toString());
         } catch (IOException | InterruptedException e){
-            String msg = "[datadog-plugin]: Failed to send log data.\n" +
-                    "[datadog-plugin]: No Further logs will be sent to Datadog.\n";
+            String msg = "Failed to send log data. No Further logs will be sent to Datadog.";
             DatadogUtilities.severe(logger, e, msg);
             try {
                 errorStream.write(msg.getBytes(charset));

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
@@ -85,15 +85,7 @@ public class DatadogWriter {
                 client.sendLogs(payload.toString());
             }
         } catch (IOException | InterruptedException e){
-            String msg = "Failed to send log data. No Further logs will be sent to Datadog.";
-            DatadogUtilities.severe(logger, e, msg);
-            try {
-                errorStream.write(msg.getBytes(charset));
-                errorStream.flush();
-            } catch (IOException ex) {
-                // This should never happen.
-                ex.printStackTrace();
-            }
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogComputerPublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogComputerPublisher.java
@@ -62,6 +62,10 @@ public class DatadogComputerPublisher extends PeriodicWork {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
+
             String hostname = DatadogUtilities.getHostname("null");
 
             long nodeCount = 0;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogComputerPublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogComputerPublisher.java
@@ -66,7 +66,7 @@ public class DatadogComputerPublisher extends PeriodicWork {
                 return;
             }
 
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
 
             long nodeCount = 0;
             long nodeOffline = 0;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogComputerPublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogComputerPublisher.java
@@ -66,7 +66,7 @@ public class DatadogComputerPublisher extends PeriodicWork {
                 return;
             }
 
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
 
             long nodeCount = 0;
             long nodeOffline = 0;
@@ -101,7 +101,7 @@ public class DatadogComputerPublisher extends PeriodicWork {
             client.gauge("jenkins.node.online", nodeOnline, hostname, globalTags);
 
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
 
     }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogCountersPublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogCountersPublisher.java
@@ -62,7 +62,7 @@ public class DatadogCountersPublisher extends AsyncPeriodicWork {
 
             client.flushCounters();
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
     }
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogCountersPublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogCountersPublisher.java
@@ -56,6 +56,10 @@ public class DatadogCountersPublisher extends AsyncPeriodicWork {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
+
             client.flushCounters();
         } catch (Exception e) {
             DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogJenkinsPublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogJenkinsPublisher.java
@@ -65,7 +65,7 @@ public class DatadogJenkinsPublisher extends PeriodicWork {
                 return;
             }
 
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             Map<String, Set<String>> tags = DatadogUtilities.getTagsFromGlobalTags();
             long projectCount = 0;
             try {
@@ -83,7 +83,7 @@ public class DatadogJenkinsPublisher extends PeriodicWork {
             client.gauge("jenkins.plugin.count", pluginCount, hostname, tags);
 
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
 
     }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogJenkinsPublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogJenkinsPublisher.java
@@ -61,6 +61,10 @@ public class DatadogJenkinsPublisher extends PeriodicWork {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
+
             String hostname = DatadogUtilities.getHostname("null");
             Map<String, Set<String>> tags = DatadogUtilities.getTagsFromGlobalTags();
             long projectCount = 0;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogJenkinsPublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogJenkinsPublisher.java
@@ -65,7 +65,7 @@ public class DatadogJenkinsPublisher extends PeriodicWork {
                 return;
             }
 
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             Map<String, Set<String>> tags = DatadogUtilities.getTagsFromGlobalTags();
             long projectCount = 0;
             try {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogQueuePublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogQueuePublisher.java
@@ -82,7 +82,7 @@ public class DatadogQueuePublisher extends PeriodicWork {
                     blocked++;
                 }
             }
-            String hostname = DatadogUtilities.getHostname("null");
+            String hostname = DatadogUtilities.getHostname(null);
             client.gauge("jenkins.queue.size", size, hostname, tags);
             client.gauge("jenkins.queue.buildable", buildable, hostname, tags);
             client.gauge("jenkins.queue.pending", pending, hostname, tags);
@@ -90,7 +90,7 @@ public class DatadogQueuePublisher extends PeriodicWork {
             client.gauge("jenkins.queue.blocked", blocked, hostname, tags);
 
         } catch (Exception e) {
-            DatadogUtilities.severe(logger, e, "An unexpected error occurred: ");
+            DatadogUtilities.severe(logger, e, null);
         }
 
     }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogQueuePublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogQueuePublisher.java
@@ -82,7 +82,7 @@ public class DatadogQueuePublisher extends PeriodicWork {
                     blocked++;
                 }
             }
-            String hostname = DatadogUtilities.getHostname(null);
+            String hostname = DatadogUtilities.getHostname("null");
             client.gauge("jenkins.queue.size", size, hostname, tags);
             client.gauge("jenkins.queue.buildable", buildable, hostname, tags);
             client.gauge("jenkins.queue.pending", pending, hostname, tags);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogQueuePublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogQueuePublisher.java
@@ -61,6 +61,10 @@ public class DatadogQueuePublisher extends PeriodicWork {
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();
+            if(client == null){
+                return;
+            }
+
             Map<String, Set<String>> tags = DatadogUtilities.getTagsFromGlobalTags();
 
             long size = 0;

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -14,7 +14,24 @@
   -->
   <f:section title="Datadog Plugin">
 
-    <f:radioBlock title="Use Datadog API URL and Key to report to Datadog" name="reportWith" value="HTTP"
+    <f:radioBlock title="Use the Datadog Agent to report to Datadog (recommended)" name="reportWith" value="DSD"
+        checked="${instance.reportWithEquals('DSD')}" inline="true">
+
+        <f:entry title="DogStatsD Host" field="targetHostEntry">
+          <f:textbox field="targetHost" default="${targetHost}" />
+        </f:entry>
+
+        <f:entry title="DogStatsD Port" field="targetPortEntry">
+          <f:textbox field="targetPort" default="${targetPort}" />
+        </f:entry>
+
+        <f:entry title="Log Collection Port" field="targetLogCollectionPortEntry">
+          <f:textbox field="targetLogCollectionPort" default="${targetLogCollectionPort}" />
+        </f:entry>
+
+    </f:radioBlock>
+
+    <f:radioBlock title="Use Datadog API URL and Key to report to Datadog (not recommended)" name="reportWith" value="HTTP"
         checked="${instance.reportWithEquals('HTTP')}" inline="true">
 
         <f:entry title="Datadog API URL" field="targetApiURLEntry" description="URL which the plugin reports to." >
@@ -29,23 +46,6 @@
           <f:password field="targetApiKey" default="${targetApiKey}" />
         </f:entry>
         <f:validateButton title="${%Test Key}" progress="${%Testing...}" method="testConnection" with="targetApiKey" />
-
-    </f:radioBlock>
-
-    <f:radioBlock title="Use a DogStatsD Server to report to Datadog" name="reportWith" value="DSD"
-        checked="${instance.reportWithEquals('DSD')}" inline="true">
-
-        <f:entry title="DogStatsD Host" field="targetHostEntry">
-          <f:textbox field="targetHost" default="${targetHost}" />
-        </f:entry>
-
-        <f:entry title="DogStatsD Port" field="targetPortEntry">
-          <f:textbox field="targetPort" default="${targetPort}" />
-        </f:entry>
-
-        <f:entry title="Log Collection Port" field="targetLogCollectionPortEntry">
-          <f:textbox field="targetLogCollectionPort" default="${targetLogCollectionPort}" />
-        </f:entry>
 
     </f:radioBlock>
 

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -21,6 +21,10 @@
           <f:textbox field="targetApiURL" default="${targetApiURL}" />
         </f:entry>
 
+        <f:entry title="Datadog Log Intake URL" field="targetLogIntakeURLEntry" description="URL which the plugin reports logs to." >
+          <f:textbox field="targetLogIntakeURL" default="${targetLogIntakeURL}" />
+        </f:entry>
+
         <f:entry title="Datadog API Key" field="targetApiKeyEntry">
           <f:password field="targetApiKey" default="${targetApiKey}" />
         </f:entry>
@@ -37,6 +41,10 @@
 
         <f:entry title="DogStatsD Port" field="targetPortEntry">
           <f:textbox field="targetPort" default="${targetPort}" />
+        </f:entry>
+
+        <f:entry title="Log Collection Port" field="targetLogCollectionPortEntry">
+          <f:textbox field="targetLogCollectionPort" default="${targetLogCollectionPort}" />
         </f:entry>
 
     </f:radioBlock>
@@ -61,7 +69,7 @@
           <f:textarea field="whitelist" optional="true" default="${whitelist}" />
         </f:entry>
 
-        <f:entry field="globalTagFileEntry" title="Global Tag File" description="Add tags from default file in workspace">
+        <f:entry field="globalTagFileEntry" title="Global Tag File" description="Add tags from default file in workspace.">
             <f:textbox field="globalTagFile" optional="true" default="${globalTagFile}"/>
         </f:entry>
 
@@ -74,12 +82,17 @@
         </f:entry>
 
         <f:entry description="Send security events like login, logout, login failure, configuration changes to jobs or changes to jenkins.">
-            <f:checkbox title="Send Security audit events" field="emitSecurityEvents" default="true"/>
+            <f:checkbox title="Send Security audit events" field="emitSecurityEvents" default="true" />
         </f:entry>
 
         <f:entry description="Send system events like Node changes of states.">
-            <f:checkbox title="Send System events" field="emitSystemEvents" default="true"/>
+            <f:checkbox title="Send System events" field="emitSystemEvents" default="true" />
         </f:entry>
+
+        <f:entry description="Enable Log Collection.">
+            <f:checkbox title="Enable Log Collection" field="collectBuildLogs" default="false" />
+        </f:entry>
+
     </f:advanced>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -35,7 +35,7 @@
     <f:radioBlock title="Use a DogStatsD Server to report to Datadog" name="reportWith" value="DSD"
         checked="${instance.reportWithEquals('DSD')}" inline="true">
 
-        <f:entry title="DogStatsD Host" field="dsdHostEntry">
+        <f:entry title="DogStatsD Host" field="targetHostEntry">
           <f:textbox field="targetHost" default="${targetHost}" />
         </f:entry>
 

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
@@ -70,7 +70,7 @@ public class DatadogClientStub implements DatadogClient {
     }
 
     @Override
-    public void setLogCollectionPort(int logCollectionPort) {
+    public void setLogCollectionPort(Integer logCollectionPort) {
 
     }
 

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
@@ -50,6 +50,11 @@ public class DatadogClientStub implements DatadogClient {
     }
 
     @Override
+    public void setLogIntakeUrl(String logIntakeUrl) {
+        // noop
+    }
+
+    @Override
     public void setApiKey(Secret apiKey) {
         // noop
     }
@@ -61,6 +66,31 @@ public class DatadogClientStub implements DatadogClient {
 
     @Override
     public void setPort(int port) {
+        // noop
+    }
+
+    @Override
+    public void setLogCollectionPort(int logCollectionPort) {
+
+    }
+
+    @Override
+    public boolean isDefaultIntakeConnectionBroken() {
+        return false;
+    }
+
+    @Override
+    public void setDefaultIntakeConnectionBroken(boolean defaultIntakeConnectionBroken) {
+        // noop
+    }
+
+    @Override
+    public boolean isLogIntakeConnectionBroken() {
+        return false;
+    }
+
+    @Override
+    public void setLogIntakeConnectionBroken(boolean logIntakeConnectionBroken) {
         // noop
     }
 
@@ -101,8 +131,8 @@ public class DatadogClientStub implements DatadogClient {
     }
 
     @Override
-    public boolean validate() throws IOException, ServletException {
-        return true;
+    public boolean sendLogs(String payloadLogs) throws IOException {
+        return false;
     }
 
     public boolean assertMetric(String name, double value, String hostname, String[] tags) {

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
@@ -131,7 +131,7 @@ public class DatadogClientStub implements DatadogClient {
     }
 
     @Override
-    public boolean sendLogs(String payloadLogs) throws IOException {
+    public boolean sendLogs(String payloadLogs) {
         return false;
     }
 

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
@@ -40,7 +40,7 @@ public class DatadogClientTest {
     @Test
     public void testIncrementCountAndFlush() throws IOException, InterruptedException {
         DatadogHttpClient.enableValidations = false;
-        DatadogClient client = DatadogHttpClient.getInstance("test", null);
+        DatadogClient client = DatadogHttpClient.getInstance("test", null, null);
         Map<String, Set<String>> tags1 = new HashMap<>();
         tags1 = DatadogClientStub.addTagToMap(tags1, "tag1", "value");
         tags1 = DatadogClientStub.addTagToMap(tags1, "tag2", "value");
@@ -101,7 +101,7 @@ public class DatadogClientTest {
             public void run() {
                 // We use a new instance of a client on every run.
                 DatadogHttpClient.enableValidations = false;
-                DatadogClient client = DatadogHttpClient.getInstance("test", null);
+                DatadogClient client = DatadogHttpClient.getInstance("test", null, null);
                 Map<String, Set<String>> tags = new HashMap<>();
                 tags = DatadogClientStub.addTagToMap(tags, "tag1", "value");
                 tags = DatadogClientStub.addTagToMap(tags, "tag2", "value");
@@ -130,7 +130,7 @@ public class DatadogClientTest {
             public void run() {
                 // We use a new instance of a client on every run.
                 DatadogHttpClient.enableValidations = false;
-                DatadogClient client = DatadogHttpClient.getInstance("test", null);
+                DatadogClient client = DatadogHttpClient.getInstance("test", null, null);
                 Map<String, Set<String>> tags = new HashMap<>();
                 tags = DatadogClientStub.addTagToMap(tags, "tag1", "value");
                 tags = DatadogClientStub.addTagToMap(tags, "tag2", "value");
@@ -170,7 +170,7 @@ public class DatadogClientTest {
         ExecutorService executor = Executors.newFixedThreadPool(2);
         // We only have one instance of the client used by all threads
         DatadogHttpClient.enableValidations = false;
-        final DatadogClient client = DatadogHttpClient.getInstance("test", null);
+        final DatadogClient client = DatadogHttpClient.getInstance("test", null, null);
         Runnable increment = new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
### What does this PR do?

Adding log collection and better exception logging when the plugin is misconfigured.

### Description of the Change

Created a package to hold the log logic. It contains 3 classes:
- `DatadogConsoleLogFilter` that extends `ConsoleLogFilter`. All it does is decorate the log outputStream with a custom `DatadogOutputStream` if needed.
- `DatadogOutputStream` extends `LineTransformationOutputStream` and mainly clean log lines from Jenkins Notes. It then uses a `DatadogWriter` class to submit logs.
- `DatadogWriter` gets contextual information to prepare the log message to be sent to Datadog.
  - As a side effect, i had to refactor the `BuildData` in order to be able to retrieve a maximum of tags/contextual info even when a listener is not provided to the constructor. In turn, i had to make changes to some methods in `DatadogUtilities` in order to be more permissive.

Added new configs:
- `logIntakeUrl` when submitting log using the Datadog API directly.
- `logCollectionPort` when submitting log using the Datadog Agent.
- `collectBuildLogs` to turn the collection on and off (default is off).

Env variable loading is not overriding the saved config anymore, hence simplifying the loading logic a little.

I also made changes regarding exception loggings. Before, if the plugin was misconfigured it would print out stack trace exceptions in stdout. It would do so repetitively because of all Publisher classes.

We no longer throw exceptions when calling `getInstance` on a client implementation.   
Even if params are not valid (null or empty), we return null. As a consequence, I had to add null checks everywhere in order to return from the calling method. Now user will see clean severe level error message in their logs.
I also added connection broken attributes (`defaultIntakeConnectionBroken` and `logIntakeConnectionBroken`) in order to prevent making bad http calls to Datadog all the time and especially when we know the connection is broken after validation.
As a consequence, i had to refactor the `validate` http client method is order to be static and independent from the current client instance singleton.

### Possible Drawbacks

When enable, log submission may have some perf implications but i haven't done any load testing at this point and it is kinda inevitable anyway.

### Verification Process

Review and manual testing mainly.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

