### PR TITLE
Set hpi.compatibleSinceVersion to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 
   <properties>
     <java.level>8</java.level>
+    <hpi.compatibleSinceVersion>1.0.0</hpi.compatibleSinceVersion>
   </properties>
 
   <licenses>


### PR DESCRIPTION
### What does this PR do?

Adds `hpi.compatibleSinceversion=1.0.0` to the plugin pom.xml.
This field allows Jenkins to show a warning upon installtion.
More details here: https://wiki.jenkins.io/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions

Version 1.0.0 introduced breaking changes but none since then.

Couldn't check if the warning is present, as it'll only show up once deployed to the maven repo.
### Additional Notes

Opening a PR from a fork as I'm still waiting on getting access to the repo from the jenkins team.

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [x] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

