### PR TITLE
Remove debugging log line

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
@@ -429,10 +429,6 @@ public class DatadogHttpClient implements DatadogClient {
                     getDatadogPluginVersion(),
                     getJavaRuntimeVersion(),
                     getJenkinsVersion()));
-            DatadogUtilities.severe(logger, null, String.format("Datadog/%s/jenkins Java/%s Jenkins/%s",
-                    getDatadogPluginVersion(),
-                    getJavaRuntimeVersion(),
-                    getJenkinsVersion()));
             conn.setUseCaches(false);
             conn.setDoInput(true);
             conn.setDoOutput(true);


### PR DESCRIPTION
### What does this PR do?

Introduced in #44 , this log line prints the Datadog user agent to the jenkins logs as severe.
This PR removes this line.

