### PR TITLE
Make ClientFactory mockable

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/ClientFactory.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/ClientFactory.java
@@ -31,9 +31,19 @@ import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration;
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
 
 public class ClientFactory {
+    private static DatadogClient testClient;
+
+    public static void setTestClient(DatadogClient testClient){
+        // Only used for tests
+        ClientFactory.testClient = testClient;
+    }
 
     public static DatadogClient getClient(DatadogClient.ClientType type, String apiUrl, String logIntakeUrl,
                                           Secret apiKey, String host, Integer port, Integer logCollectionPort){
+        if(testClient != null){
+            // Only used for tests
+            return testClient;
+        }
         switch(type){
             case HTTP:
                 return DatadogHttpClient.getInstance(apiUrl, logIntakeUrl, apiKey);


### PR DESCRIPTION
ClientFactory is a static factory which makes it hard to mock without refactoring most of the code.
Using Powermock was considered as well, but the PowerMockRunner.class leads to issues when creating JenkinsRule and especially when creating slaves.

i.e the following ends up in an infinite loop and never create the slave when inside a test class ran by PowerMockRunner

```java

@RunWith(PowerMockRunner.class) //Removing this makes it works
class MyTest {

   @Rule
   public JenkinsRule j = new JenkinsRule()

   @Before
   public void setup() {
      j.createOnlineSlave("test", null, null)
  }
}
```