### PR TITLE
Collect and submit jenkins.job.stage_duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,46 +197,47 @@ NOTE: `event_type` is always set to `security` for above events and metrics.
 
 ### Metrics
 
-| Metric Name                            | Description                                                    | Default Tags                                                |
-|----------------------------------------|----------------------------------------------------------------|-------------------------------------------------------------|
-| `jenkins.computer.launch_failure`      | Rate of computer launch failures.                              | `jenkins_url`                                               |
-| `jenkins.computer.offline`             | Rate of computer going offline.                                | `jenkins_url`                                               |
-| `jenkins.computer.online`              | Rate of computer going online.                                 | `jenkins_url`                                               |
-| `jenkins.computer.temporarily_offline` | Rate of computer going temporarily offline.                    | `jenkins_url`                                               |
-| `jenkins.computer.temporarily_online`  | Rate of computer going temporarily online.                     | `jenkins_url`                                               |
-| `jenkins.config.changed`               | Rate of configs being changed.                                 | `jenkins_url`, `user_id`                                    |
-| `jenkins.executor.count`               | Executor count.                                                | `jenkins_url`, `node_hostname`, `node_name`, `node_label`   |
-| `jenkins.executor.free`                | Number of unused executor.                                     | `jenkins_url`, `node_hostname`, `node_name`, `node_label`   |
-| `jenkins.executor.in_use`              | Number of idle executor.                                       | `jenkins_url`, `node_hostname`, `node_name`, `node_label`   |
-| `jenkins.item.copied`                  | Rate of items being copied.                                    | `jenkins_url`, `user_id`                                    |
-| `jenkins.item.created`                 | Rate of items being created.                                   | `jenkins_url`, `user_id`                                    |
-| `jenkins.item.deleted`                 | Rate of items being deleted.                                   | `jenkins_url`, `user_id`                                    |
-| `jenkins.item.location_changed`        | Rate of items being moved.                                     | `jenkins_url`, `user_id`                                    |
-| `jenkins.item.updated`                 | Rate of items being updated.                                   | `jenkins_url`, `user_id`                                    |
-| `jenkins.job.aborted`                  | Rate of aborted jobs.                                          | `branch`, `jenkins_url`, `job`, `node`, `user_id`           |
-| `jenkins.job.completed`                | Rate of completed jobs.                                        | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id` |
-| `jenkins.job.cycletime`                | Build Cycle Time.                                              | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id` |
-| `jenkins.job.duration`                 | Build duration (in seconds).                                   | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id` |
-| `jenkins.job.feedbacktime`             | Feedback time from code commit to job failure.                 | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id` |
-| `jenkins.job.leadtime`                 | Build Lead Time.                                               | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id` |
-| `jenkins.job.mtbf`                     | MTBF, time between last successful job and current failed job. | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id` |
-| `jenkins.job.mttr`                     | MTTR: time between last failed job and current successful job. | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id` |
-| `jenkins.job.started`                  | Rate of started jobs.                                          | `branch`, `jenkins_url`, `job`, `node`, `user_id`           |
-| `jenkins.job.waiting`                  | Time spent waiting for job to run (in milliseconds).           | `branch`, `jenkins_url`, `job`, `node`, `user_id`           |
-| `jenkins.node.count`                   | Total number of node.                                          | `jenkins_url`                                               |
-| `jenkins.node.offline`                 | Offline nodes count.                                           | `jenkins_url`                                               |
-| `jenkins.node.online`                  | Online nodes count.                                            | `jenkins_url`                                               |
-| `jenkins.plugin.count`                 | Plugins count.                                                 | `jenkins_url`                                               |
-| `jenkins.project.count`                | Project count.                                                 | `jenkins_url`                                               |
-| `jenkins.queue.size`                   | Queue Size.                                                    | `jenkins_url`                                               |
-| `jenkins.queue.buildable`              | Number of Buildable item in Queue.                             | `jenkins_url`                                               |
-| `jenkins.queue.pending`                | Number of Pending item in Queue.                               | `jenkins_url`                                               |
-| `jenkins.queue.stuck`                  | Number of Stuck item in Queue.                                 | `jenkins_url`                                               |
-| `jenkins.queue.blocked`                | Number of Blocked item in Queue.                               | `jenkins_url`                                               |
-| `jenkins.scm.checkout`                 | Rate of SCM checkouts.                                         | `branch`, `jenkins_url`, `job`, `node`, `user_id`           |
-| `jenkins.user.access_denied`           | Rate of users failing to authenticate.                         | `jenkins_url`, `user_id`                                    |
-| `jenkins.user.authenticated`           | Rate of users authenticating.                                  | `jenkins_url`, `user_id`                                    |
-| `jenkins.user.logout`                  | Rate of users logging out.                                     | `jenkins_url`, `user_id`                                    |
+| Metric Name                            | Description                                                    | Default Tags                                                               |
+|----------------------------------------|----------------------------------------------------------------|----------------------------------------------------------------------------|
+| `jenkins.computer.launch_failure`      | Rate of computer launch failures.                              | `jenkins_url`                                                              |
+| `jenkins.computer.offline`             | Rate of computer going offline.                                | `jenkins_url`                                                              |
+| `jenkins.computer.online`              | Rate of computer going online.                                 | `jenkins_url`                                                              |
+| `jenkins.computer.temporarily_offline` | Rate of computer going temporarily offline.                    | `jenkins_url`                                                              |
+| `jenkins.computer.temporarily_online`  | Rate of computer going temporarily online.                     | `jenkins_url`                                                              |
+| `jenkins.config.changed`               | Rate of configs being changed.                                 | `jenkins_url`, `user_id`                                                   |
+| `jenkins.executor.count`               | Executor count.                                                | `jenkins_url`, `node_hostname`, `node_name`, `node_label`                  |
+| `jenkins.executor.free`                | Number of unused executor.                                     | `jenkins_url`, `node_hostname`, `node_name`, `node_label`                  |
+| `jenkins.executor.in_use`              | Number of idle executor.                                       | `jenkins_url`, `node_hostname`, `node_name`, `node_label`                  |
+| `jenkins.item.copied`                  | Rate of items being copied.                                    | `jenkins_url`, `user_id`                                                   |
+| `jenkins.item.created`                 | Rate of items being created.                                   | `jenkins_url`, `user_id`                                                   |
+| `jenkins.item.deleted`                 | Rate of items being deleted.                                   | `jenkins_url`, `user_id`                                                   |
+| `jenkins.item.location_changed`        | Rate of items being moved.                                     | `jenkins_url`, `user_id`                                                   |
+| `jenkins.item.updated`                 | Rate of items being updated.                                   | `jenkins_url`, `user_id`                                                   |
+| `jenkins.job.aborted`                  | Rate of aborted jobs.                                          | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
+| `jenkins.job.completed`                | Rate of completed jobs.                                        | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
+| `jenkins.job.cycletime`                | Build Cycle Time.                                              | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
+| `jenkins.job.duration`                 | Build duration (in seconds).                                   | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
+| `jenkins.job.feedbacktime`             | Feedback time from code commit to job failure.                 | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
+| `jenkins.job.leadtime`                 | Build Lead Time.                                               | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
+| `jenkins.job.mtbf`                     | MTBF, time between last successful job and current failed job. | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
+| `jenkins.job.mttr`                     | MTTR: time between last failed job and current successful job. | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
+| `jenkins.job.started`                  | Rate of started jobs.                                          | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
+| `jenkins.job.stageduration`            | Duration of individual stages                                  | `jenkins_url`, `job`, user_id`, `stage_name`, `stage_depth`, `stage_parent`|
+| `jenkins.job.waiting`                  | Time spent waiting for job to run (in milliseconds).           | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
+| `jenkins.node.count`                   | Total number of node.                                          | `jenkins_url`                                                              |
+| `jenkins.node.offline`                 | Offline nodes count.                                           | `jenkins_url`                                                              |
+| `jenkins.node.online`                  | Online nodes count.                                            | `jenkins_url`                                                              |
+| `jenkins.plugin.count`                 | Plugins count.                                                 | `jenkins_url`                                                              |
+| `jenkins.project.count`                | Project count.                                                 | `jenkins_url`                                                              |
+| `jenkins.queue.size`                   | Queue Size.                                                    | `jenkins_url`                                                              |
+| `jenkins.queue.buildable`              | Number of Buildable item in Queue.                             | `jenkins_url`                                                              |
+| `jenkins.queue.pending`                | Number of Pending item in Queue.                               | `jenkins_url`                                                              |
+| `jenkins.queue.stuck`                  | Number of Stuck item in Queue.                                 | `jenkins_url`                                                              |
+| `jenkins.queue.blocked`                | Number of Blocked item in Queue.                               | `jenkins_url`                                                              |
+| `jenkins.scm.checkout`                 | Rate of SCM checkouts.                                         | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
+| `jenkins.user.access_denied`           | Rate of users failing to authenticate.                         | `jenkins_url`, `user_id`                                                   |
+| `jenkins.user.authenticated`           | Rate of users authenticating.                                  | `jenkins_url`, `user_id`                                                   |
+| `jenkins.user.logout`                  | Rate of users logging out.                                     | `jenkins_url`, `user_id`                                                   |
 
 ### Service checks
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ NOTE: `event_type` is always set to `security` for above events and metrics.
 | `jenkins.job.mtbf`                     | MTBF, time between last successful job and current failed job. | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
 | `jenkins.job.mttr`                     | MTTR: time between last failed job and current successful job. | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
 | `jenkins.job.started`                  | Rate of started jobs.                                          | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
-| `jenkins.job.stageduration`            | Duration of individual stages.                                 | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`|
+| `jenkins.job.stage_duration`            | Duration of individual stages.                                 | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`|
 | `jenkins.job.waiting`                  | Time spent waiting for job to run (in milliseconds).           | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
 | `jenkins.node.count`                   | Total number of node.                                          | `jenkins_url`                                                              |
 | `jenkins.node.offline`                 | Offline nodes count.                                           | `jenkins_url`                                                              |

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ NOTE: `event_type` is always set to `security` for above events and metrics.
 | `jenkins.job.mtbf`                     | MTBF, time between last successful job and current failed job. | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
 | `jenkins.job.mttr`                     | MTTR: time between last failed job and current successful job. | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
 | `jenkins.job.started`                  | Rate of started jobs.                                          | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
-| `jenkins.job.stageduration`            | Duration of individual stages                                  | `jenkins_url`, `job`, user_id`, `stage_name`, `stage_depth`, `stage_parent`|
+| `jenkins.job.stageduration`            | Duration of individual stages.                                 | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`|
 | `jenkins.job.waiting`                  | Time spent waiting for job to run (in milliseconds).           | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
 | `jenkins.node.count`                   | Total number of node.                                          | `jenkins_url`                                                              |
 | `jenkins.node.offline`                 | Offline nodes count.                                           | `jenkins_url`                                                              |

--- a/pom.xml
+++ b/pom.xml
@@ -93,11 +93,21 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+      <version>1.4.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListener.java
@@ -95,7 +95,7 @@ public class DatadogGraphListener implements GraphListener {
             TagsUtil.addTagToTags(tags, "stage_depth", String.valueOf(stageDepth));
             tags.remove("result"); // Jenkins sometimes consider the build has a result even though it's still running.
                                         // Stage metrics should never report a result.
-            client.gauge("jenkins.job.stageduration", getTime(startNode, endNode), hostname, tags);
+            client.gauge("jenkins.job.stage_duration", getTime(startNode, endNode), hostname, tags);
         } catch (IOException | InterruptedException e) {
             DatadogUtilities.severe(logger, e, "Unable to submit the stage duration metric for " + getStageName(startNode));
         }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListener.java
@@ -1,0 +1,158 @@
+/*
+The MIT License
+
+Copyright (c) 2015-Present Datadog, Inc <opensource@datadoghq.com>
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+ */
+
+package org.datadog.jenkins.plugins.datadog.listeners;
+
+import hudson.Extension;
+import hudson.model.Queue;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.datadog.jenkins.plugins.datadog.DatadogClient;
+import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
+import org.datadog.jenkins.plugins.datadog.clients.ClientFactory;
+import org.datadog.jenkins.plugins.datadog.model.BuildData;
+import org.datadog.jenkins.plugins.datadog.util.TagsUtil;
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.actions.StageAction;
+import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
+import org.jenkinsci.plugins.workflow.actions.TimingAction;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
+import org.jenkinsci.plugins.workflow.flow.GraphListener;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+
+/**
+ * A GraphListener implementation which computes timing information
+ * for the various stages in a pipeline.
+ */
+@Extension
+public class DatadogGraphListener implements GraphListener {
+
+    private static final Logger logger = Logger.getLogger(DatadogGraphListener.class.getName());
+
+    @Override
+    public void onNewHead(FlowNode flowNode) {
+        if (!isMonitored(flowNode)) {
+            return;
+        }
+        StepEndNode endNode = (StepEndNode) flowNode;
+        StepStartNode startNode = endNode.getStartNode();
+        int stage_depth = 0;
+        for (BlockStartNode node : startNode.iterateEnclosingBlocks()) {
+            if (isStageNode(node)) {
+                stage_depth++;
+            }
+        }
+        DatadogClient client = ClientFactory.getClient();
+        try {
+            BuildData buildData = new BuildData(getRun(flowNode), flowNode.getExecution().getOwner().getListener());
+            String hostname = buildData.getHostname("");
+            Map<String, Set<String>> tags = buildData.getTags();
+            TagsUtil.addTagToTags(tags, "stage_name", getStageName(startNode));
+            TagsUtil.addTagToTags(tags, "stage_depth", String.valueOf(stage_depth));
+            tags.remove("result"); // Jenkins sometimes consider the build has a result even though it's still running.
+            client.gauge("jenkins.job.stageduration", getTime(startNode, endNode), hostname, tags);
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private boolean isMonitored(FlowNode flowNode) {
+        // Filter the node out if it is not the end of step
+        // Timing information is only available once the step has completed.
+        if (!(flowNode instanceof StepEndNode)) {
+            return false;
+        }
+
+        // Filter the node if the job has been blacklisted from the Datadog plugin configuration.
+        WorkflowRun run = getRun(flowNode);
+        if (run == null || !DatadogUtilities.isJobTracked(run.getParent().getFullName())) {
+            return false;
+        }
+
+        // Filter the node out if it is not the end of a stage.
+        // The plugin only monitors timing information of stages
+        return isStageNode(((StepEndNode) flowNode).getStartNode());
+
+        // Finally return true as this node is the end of a monitored stage.
+    }
+
+    @CheckForNull
+    private WorkflowRun getRun(@Nonnull FlowNode flowNode) {
+        Queue.Executable exec;
+        try {
+            exec = flowNode.getExecution().getOwner().getExecutable();
+        } catch (IOException e) {
+            // Ignore the error, that step cannot be monitored.
+            return null;
+        }
+
+        // TODO: WorkflowRun or Run ?
+        if (exec instanceof WorkflowRun) {
+            return (WorkflowRun) exec;
+        }
+        return null;
+    }
+
+    boolean isStageNode(BlockStartNode flowNode) {
+        if (flowNode == null) {
+            return false;
+        }
+        if (flowNode.getAction(StageAction.class) != null) {
+            // Legacy style stage block without a body
+            // https://groups.google.com/g/jenkinsci-users/c/MIVk-44cUcA
+            return true;
+        }
+        if (flowNode.getAction(ThreadNameAction.class) != null) {
+            // TODO comment
+            return false;
+        }
+        return flowNode.getAction(LabelAction.class) != null;
+    }
+
+    String getStageName(@Nonnull StepStartNode flowNode) {
+        ThreadNameAction threadNameAction = flowNode.getAction(ThreadNameAction.class);
+        if (threadNameAction != null) {
+            return threadNameAction.getThreadName();
+        }
+        return flowNode.getDisplayName();
+    }
+
+    long getTime(FlowNode startNode, FlowNode endNode) {
+        TimingAction startTime = startNode.getAction(TimingAction.class);
+        TimingAction endTime = endNode.getAction(TimingAction.class);
+
+        if (startTime != null && endTime != null) {
+            return endTime.getStartTime() - startTime.getStartTime();
+        }
+        return 0;
+    }
+}

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
@@ -151,6 +151,7 @@ public class DatadogClientStub implements DatadogClient {
     }
 
     public boolean assertMetric(String name, String hostname, String[] tags) {
+        // Assert that a metric with the same name and tags has already been submitted without checking the value.
         DatadogMetric m = new DatadogMetric(name, 0, hostname, Arrays.asList(tags));
         Optional<DatadogMetric> match = this.metrics.stream().filter(t -> t.same(m)).findFirst();
         if(match.isPresent()){

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
@@ -26,14 +26,11 @@ THE SOFTWARE.
 package org.datadog.jenkins.plugins.datadog.clients;
 
 import hudson.util.Secret;
-import net.sf.json.JSON;
 import net.sf.json.JSONObject;
 import org.datadog.jenkins.plugins.datadog.DatadogClient;
 import org.datadog.jenkins.plugins.datadog.DatadogEvent;
 import org.junit.Assert;
 
-import javax.servlet.ServletException;
-import java.io.IOException;
 import java.util.*;
 
 public class DatadogClientStub implements DatadogClient {
@@ -149,6 +146,18 @@ public class DatadogClientStub implements DatadogClient {
             return true;
         }
         Assert.fail("metric { " + m.toString() + " does not exist. " +
+                "metrics: {" + this.metrics.toString() + " }");
+        return false;
+    }
+
+    public boolean assertMetric(String name, String hostname, String[] tags) {
+        DatadogMetric m = new DatadogMetric(name, 0, hostname, Arrays.asList(tags));
+        Optional<DatadogMetric> match = this.metrics.stream().filter(t -> t.same(m)).findFirst();
+        if(match.isPresent()){
+            this.metrics.remove(match.get());
+            return true;
+        }
+        Assert.fail("metric { " + m.toString() + " does not exist (ignoring value). " +
                 "metrics: {" + this.metrics.toString() + " }");
         return false;
     }

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
@@ -1,0 +1,179 @@
+package org.datadog.jenkins.plugins.datadog.listeners;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import hudson.model.labels.LabelAtom;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
+import org.datadog.jenkins.plugins.datadog.clients.ClientFactory;
+import org.datadog.jenkins.plugins.datadog.clients.DatadogClientStub;
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
+import org.jenkinsci.plugins.workflow.actions.TimingAction;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class DatadogGraphListenerTest {
+
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
+    private DatadogGraphListener listener;
+    private DatadogClientStub clientStub;
+
+    @Before
+    public void beforeEach() {
+        listener = new DatadogGraphListener();
+        clientStub = new DatadogClientStub();
+        ClientFactory.setTestClient(clientStub);
+    }
+
+    private StepStartNode makeMonitorableStartNode(String label) {
+        StepStartNode startNode = mock(StepStartNode.class);
+        when(startNode.getAction(LabelAction.class)).thenReturn(new LabelAction(label));
+        when(startNode.getDisplayName()).thenReturn(label);
+        return startNode;
+    }
+
+    @Test
+    public void testNewNode() throws IOException {
+        StepStartNode startNode = makeMonitorableStartNode("low");
+        StepEndNode endNode = mock(StepEndNode.class);
+        when(endNode.getStartNode()).thenReturn(startNode);
+
+        long startTime = 10L, endTime = 12345L;
+
+        TimingAction startAction = mock(TimingAction.class);
+        when(startAction.getStartTime()).thenReturn(startTime);
+        TimingAction endAction = mock(TimingAction.class);
+        when(endAction.getStartTime()).thenReturn(endTime);
+
+        when(startNode.getAction(TimingAction.class)).thenReturn(startAction);
+        when(endNode.getAction(TimingAction.class)).thenReturn(endAction);
+
+        List<BlockStartNode> enclosingBlocks = new ArrayList<>();
+        enclosingBlocks.add(makeMonitorableStartNode("medium"));
+        enclosingBlocks.add(makeMonitorableStartNode("high"));
+        when(startNode.iterateEnclosingBlocks()).thenReturn(enclosingBlocks);
+
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "pipeline");
+        WorkflowRun run = new WorkflowRun(job);
+
+        FlowExecutionOwner flowExecutionOwner = mock(FlowExecutionOwner.class);
+        when(flowExecutionOwner.getExecutable()).thenReturn(run);
+        FlowExecution flowExecution = mock(FlowExecution.class);
+        when(flowExecution.getOwner()).thenReturn(flowExecutionOwner);
+        when(endNode.getExecution()).thenReturn(flowExecution);
+
+        listener.onNewHead(endNode);
+        String hostname = DatadogUtilities.getHostname(null);
+        String[] expectedTags = new String[]{
+                "jenkins_url:" + DatadogUtilities.getJenkinsUrl(),
+                "user_id:anonymous",
+                "stage_name:low",
+                "job:pipeline",
+                "stage_depth:2"
+        };
+        clientStub.assertMetric("jenkins.job.stageduration", endTime - startTime, hostname, expectedTags);
+    }
+
+    @Test
+    public void testIntegration() throws Exception {
+        jenkinsRule.createOnlineSlave(new LabelAtom("windows"));
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "pipelineIntegration");
+        String definition = IOUtils.toString(
+                this.getClass().getResourceAsStream("testPipelineDefinition.txt"),
+                "UTF-8"
+        );
+        job.setDefinition(new CpsFlowDefinition(definition, true));
+        WorkflowRun run = job.scheduleBuild2(0).get();
+        BufferedReader br = new BufferedReader(run.getLogReader());
+        String s;
+        while ((s = br.readLine()) != null) {
+            System.out.println(s);
+        }
+        br.close();
+        String hostname = DatadogUtilities.getHostname(null);
+        String[] baseTags = new String[]{
+                "jenkins_url:" + DatadogUtilities.getJenkinsUrl(),
+                "user_id:anonymous",
+                "job:pipelineIntegration"
+        };
+        String[] depths = new String[]{ "2", "2", "2", "1", "1", "0", "0" };
+        String[] stageNames = new String[]{ "Windows-1", "Windows-2", "Windows-3", "Test On Windows", "Test On Linux", "Parallel tests",
+                "Pre-setup" };
+        for (int i = 0; i < depths.length; i++) {
+            String[] expectedTags = Arrays.copyOf(baseTags, baseTags.length + 2);
+            expectedTags[expectedTags.length - 2] = "stage_depth:" + depths[i];
+            expectedTags[expectedTags.length - 1] = "stage_name:" + stageNames[i];
+            clientStub.assertMetric("jenkins.job.stageduration", hostname, expectedTags);
+        }
+
+    }
+
+    @Test
+    public void isStageNodeTest() {
+        Assert.assertFalse(listener.isStageNode(null));
+        BlockStartNode node = mock(BlockStartNode.class);
+        Assert.assertFalse(listener.isStageNode(node));
+
+        when(node.getAction(LabelAction.class)).thenReturn(mock(LabelAction.class));
+        Assert.assertTrue(listener.isStageNode(node));
+
+        when(node.getAction(ThreadNameAction.class)).thenReturn(mock(ThreadNameAction.class));
+        Assert.assertFalse(listener.isStageNode(node));
+    }
+
+    @Test
+    public void getStageNameTest() {
+        String stageName = "Hello world";
+        StepStartNode node = mock(StepStartNode.class);
+        when(node.getDisplayName()).thenReturn(stageName);
+
+        // Regular stage with no thread
+        when(node.getAction(ThreadNameAction.class)).thenReturn(null);
+        Assert.assertEquals(listener.getStageName(node), stageName);
+
+        // Parallel stage
+        String stageNameThread = "Hello thread";
+        ThreadNameAction threadNameAction = mock(ThreadNameAction.class);
+        when(threadNameAction.getThreadName()).thenReturn(stageNameThread);
+        when(node.getAction(ThreadNameAction.class)).thenReturn(threadNameAction);
+        Assert.assertEquals(listener.getStageName(node), stageNameThread);
+    }
+
+
+    @Test
+    public void getTimeTest() {
+        long startTime = 10L, endTime = 12345L;
+
+        TimingAction startAction = mock(TimingAction.class);
+        when(startAction.getStartTime()).thenReturn(startTime);
+        TimingAction endAction = mock(TimingAction.class);
+        when(endAction.getStartTime()).thenReturn(endTime);
+
+        StepStartNode startNode = mock(StepStartNode.class);
+        when(startNode.getAction(TimingAction.class)).thenReturn(startAction);
+        StepEndNode endNode = mock(StepEndNode.class);
+        when(endNode.getAction(TimingAction.class)).thenReturn(endAction);
+
+        Assert.assertEquals(endTime - startTime, listener.getTime(startNode, endNode));
+    }
+
+}

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
@@ -88,6 +88,7 @@ public class DatadogGraphListenerTest {
                 "user_id:anonymous",
                 "stage_name:low",
                 "job:pipeline",
+                "parent_stage_name:medium",
                 "stage_depth:2"
         };
         clientStub.assertMetric("jenkins.job.stageduration", endTime - startTime, hostname, expectedTags);
@@ -118,10 +119,14 @@ public class DatadogGraphListenerTest {
         String[] depths = new String[]{ "2", "2", "2", "1", "1", "0", "0" };
         String[] stageNames = new String[]{ "Windows-1", "Windows-2", "Windows-3", "Test On Windows", "Test On Linux", "Parallel tests",
                 "Pre-setup" };
+        String[] parentNames = new String[]{ "Test On Windows", "Test On Windows", "Test On Windows", "Parallel tests", "Parallel tests", "root", "root" };
+
         for (int i = 0; i < depths.length; i++) {
-            String[] expectedTags = Arrays.copyOf(baseTags, baseTags.length + 2);
-            expectedTags[expectedTags.length - 2] = "stage_depth:" + depths[i];
-            expectedTags[expectedTags.length - 1] = "stage_name:" + stageNames[i];
+            String[] expectedTags = Arrays.copyOf(baseTags, baseTags.length + 3);
+            expectedTags[expectedTags.length - 3] = "stage_depth:" + depths[i];
+            expectedTags[expectedTags.length - 2] = "stage_name:" + stageNames[i];
+            expectedTags[expectedTags.length - 1] = "parent_stage_name:" + parentNames[i];
+
             clientStub.assertMetric("jenkins.job.stageduration", hostname, expectedTags);
         }
 

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
@@ -91,7 +91,7 @@ public class DatadogGraphListenerTest {
                 "parent_stage_name:medium",
                 "stage_depth:2"
         };
-        clientStub.assertMetric("jenkins.job.stageduration", endTime - startTime, hostname, expectedTags);
+        clientStub.assertMetric("jenkins.job.stage_duration", endTime - startTime, hostname, expectedTags);
     }
 
     @Test
@@ -127,7 +127,7 @@ public class DatadogGraphListenerTest {
             expectedTags[expectedTags.length - 2] = "stage_name:" + stageNames[i];
             expectedTags[expectedTags.length - 1] = "parent_stage_name:" + parentNames[i];
 
-            clientStub.assertMetric("jenkins.job.stageduration", hostname, expectedTags);
+            clientStub.assertMetric("jenkins.job.stage_duration", hostname, expectedTags);
         }
 
     }

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineDefinition.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineDefinition.txt
@@ -1,0 +1,54 @@
+pipeline {
+    agent none
+    stages {
+        stage('Pre-setup'){
+            steps {
+                echo 'Hello world'
+            }
+        }
+        stage('Parallel tests') {
+            parallel {
+                stage('Test On Windows') {
+                    agent {
+                        label "windows"
+                    }
+                    stages {
+                        stage('Windows-1'){
+                            steps{
+                            sh "echo 'Windows 1'"
+                            }
+                        }
+                        stage('Windows-2'){
+                            steps{
+                            sh "echo 'Windows 2'"
+                            }
+                        }
+                        stage('Windows-3'){
+                            steps{
+                            sh "echo 'Windows 3'"
+                            }
+                        }
+                    }
+                    post {
+                        always {
+                            sh "echo 'done'"
+                        }
+                    }
+                }
+                stage('Test On Linux') {
+                    agent {
+                        label "master"
+                    }
+                    steps {
+                        sh "echo 'Linux'"
+                    }
+                    post {
+                        always {
+                            sh "echo 'done'"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new listener "DatadogGraphListener" that is called on every start of a 'node' in a pipeline.

When the hook is called with a StepEndNode, we now that a "part" of the pipeline has completed. The listener then fetches the corresponding StartEndNode, verifies that this node is indeed a "stage", and if so submit a "jenkins.job.duration" metric with the timing difference between the start node and the end node.

## How does the lister handles stages within stages ?

For each stage (no matter its depth) a metric will be submitted with the corresponding `stage_name` tag. Additionally, a stage_depth tag is added to those metrics that represent how deep the stage is in the pipeline.

It can be useful when querying those metrics if for example one want to see the duration of all top level stages of a pipeline.