### PR TITLE
Update config access through lookupSingleton method

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -55,8 +55,8 @@ public class DatadogUtilities {
      */
     public static DatadogGlobalConfiguration getDatadogGlobalDescriptor() {
         try {
-            return ExtensionList.lookup(DatadogGlobalConfiguration.class).get(DatadogGlobalConfiguration.class);
-        } catch(NullPointerException e){
+            return ExtensionList.lookupSingleton(DatadogGlobalConfiguration.class);
+        } catch (IllegalStateException e) {
             // It can only throw a NullPointerException when running tests
             return null;
         }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -57,7 +57,7 @@ public class DatadogUtilities {
         try {
             return ExtensionList.lookupSingleton(DatadogGlobalConfiguration.class);
         } catch (IllegalStateException e) {
-            // It can only throw a NullPointerException when running tests
+            // It can only throw a IllegalStateException when running tests
             return null;
         }
     }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
@@ -131,8 +131,20 @@ public class DatadogHttpClient implements DatadogClient {
         if (apiKey == null || Secret.toString(apiKey).isEmpty()){
             throw new IllegalArgumentException("Datadog API Key is not set properly");
         }
-        if (DatadogHttpClient.isCollectBuildLogEnabled() && (logIntakeUrl == null || logIntakeUrl.isEmpty())){
-            throw new IllegalArgumentException("Datadog Log Intake URL is not set properly");
+        if (DatadogUtilities.getDatadogGlobalDescriptor().isCollectBuildLogs() ) {
+            if (logIntakeUrl == null || logIntakeUrl.isEmpty()) {
+                throw new IllegalArgumentException("Datadog Log Intake URL is not set properly");
+            }
+            try {
+                boolean logConnection = validateLogIntakeConnection(url, apiKey);
+                if (!logConnection) {
+                    instance.setLogIntakeConnectionBroken(true);
+                    throw new IllegalArgumentException("Connection broken, please double check both your Log Intake URL and Key");
+                }
+            } catch (IOException e) {
+                instance.setLogIntakeConnectionBroken(true);
+                throw new IllegalArgumentException("Connection broken, please double check both your Log Intake URL and Key");
+            }
         }
         try {
             boolean intakeConnection = validateDefaultIntakeConnection(url, apiKey);
@@ -144,18 +156,6 @@ public class DatadogHttpClient implements DatadogClient {
         } catch (IOException e) {
             instance.setDefaultIntakeConnectionBroken(true);
             throw new IllegalArgumentException("Connection broken, please double check both your API URL and Key");
-        }
-        if (DatadogHttpClient.isCollectBuildLogEnabled()) {
-            try {
-                boolean logConnection = validateLogIntakeConnection(url, apiKey);
-                if (!logConnection) {
-                    instance.setLogIntakeConnectionBroken(true);
-                    throw new IllegalArgumentException("Connection broken, please double check both your Log Intake URL and Key");
-                }
-            } catch (IOException e) {
-                instance.setLogIntakeConnectionBroken(true);
-                throw new IllegalArgumentException("Connection broken, please double check both your Log Intake URL and Key");
-            }
         }
     }
 
@@ -646,10 +646,4 @@ public class DatadogHttpClient implements DatadogClient {
         }
         return this.jenkinsVersion;
     }
-
-    private static boolean isCollectBuildLogEnabled(){
-        return DatadogUtilities.getDatadogGlobalDescriptor() != null &&
-                DatadogUtilities.getDatadogGlobalDescriptor().isCollectBuildLogs();
-    }
-
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DogStatsDClient.java
@@ -119,7 +119,7 @@ public class DogStatsDClient implements DatadogClient {
         if (port == null) {
             throw new IllegalArgumentException("Datadog Target Port is not set properly");
         }
-        if (DogStatsDClient.isCollectBuildLogEnabled() && logCollectionPort == null) {
+        if (DatadogUtilities.getDatadogGlobalDescriptor().isCollectBuildLogs()  && logCollectionPort == null) {
             throw new IllegalArgumentException("Datadog Log Collection Port is not set properly");
         }
         return;
@@ -183,7 +183,7 @@ public class DogStatsDClient implements DatadogClient {
         if(this.ddLogger != null && !force){
             return true;
         }
-        if(!isCollectBuildLogEnabled() || this.logCollectionPort == null){
+        if(!DatadogUtilities.getDatadogGlobalDescriptor().isCollectBuildLogs() || this.logCollectionPort == null){
             return false;
         }
         try {
@@ -423,10 +423,4 @@ public class DogStatsDClient implements DatadogClient {
         }
         return true;
     }
-
-    private static boolean isCollectBuildLogEnabled(){
-        return DatadogUtilities.getDatadogGlobalDescriptor() != null &&
-                DatadogUtilities.getDatadogGlobalDescriptor().isCollectBuildLogs();
-    }
-
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogConsoleLogFilter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogConsoleLogFilter.java
@@ -28,6 +28,7 @@ package org.datadog.jenkins.plugins.datadog.logs;
 import hudson.Extension;
 import hudson.console.ConsoleLogFilter;
 import hudson.model.*;
+
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
 
 import javax.annotation.Nonnull;
@@ -52,8 +53,7 @@ public class DatadogConsoleLogFilter extends ConsoleLogFilter implements Seriali
 
     public OutputStream decorateLogger(Run build, OutputStream outputStream) throws IOException, InterruptedException {
         try {
-            if (DatadogUtilities.getDatadogGlobalDescriptor() == null ||
-                    !DatadogUtilities.getDatadogGlobalDescriptor().isCollectBuildLogs()) {
+            if (!DatadogUtilities.getDatadogGlobalDescriptor().isCollectBuildLogs()) {
                 logger.fine("Log Collection disabled");
                 return outputStream;
             }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogTaskListenerDecorator.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogTaskListenerDecorator.java
@@ -32,6 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -59,8 +60,7 @@ public class DatadogTaskListenerDecorator extends TaskListenerDecorator {
         @Override
         @Nullable
         public TaskListenerDecorator of(@Nonnull FlowExecutionOwner owner) {
-            if (DatadogUtilities.getDatadogGlobalDescriptor() == null ||
-                    !DatadogUtilities.getDatadogGlobalDescriptor().isCollectBuildLogs()) {
+            if (!DatadogUtilities.getDatadogGlobalDescriptor().isCollectBuildLogs()) {
                 return null;
             }
             try {

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
@@ -27,7 +27,9 @@ package org.datadog.jenkins.plugins.datadog.clients;
 
 import org.datadog.jenkins.plugins.datadog.DatadogClient;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -36,6 +38,9 @@ import java.util.Set;
 import java.util.concurrent.*;
 
 public class DatadogClientTest {
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
 
     @Test
     public void testHttpClientGetInstanceApiKey() {

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/logs/LogCollectionTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/logs/LogCollectionTest.java
@@ -9,6 +9,7 @@ import hudson.tasks.Shell;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins.MasterComputer;
 import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration;
+import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
 import org.datadog.jenkins.plugins.datadog.clients.ClientFactory;
 import org.datadog.jenkins.plugins.datadog.clients.DatadogClientStub;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -29,7 +30,7 @@ public class LogCollectionTest {
     @BeforeClass
     public static void setup() throws Exception {
         ClientFactory.setTestClient(stubClient);
-        DatadogGlobalConfiguration cfg = ExtensionList.lookup(DatadogGlobalConfiguration.class).get(0);
+        DatadogGlobalConfiguration cfg = DatadogUtilities.getDatadogGlobalDescriptor();
         ExtensionList.clearLegacyInstances();
         cfg.setCollectBuildLogs(true);
         j.createOnlineSlave(new LabelAtom("test"));


### PR DESCRIPTION
### What does this PR do?

Implements more unified access to global configuration through the single utility function.

What inspired you to submit this pull request?
https://github.com/jenkinsci/datadog-plugin/pull/59#discussion_r427529830

### Description of the Change

All configuration requests now go through the utility class, which performs the standard approach of `lookupSingleton` for retrieving the class.

This has the drawback of requiring a Jenkins instance during tests (because of the `DatadogGlobalConfiguration.load()` operation), else an exception gets raised, so we still wrap the access in a try/catch to maintain support for existing test scenarios.

### Alternate Designs

Adding a `get` method on the `DatadogGlobalConfiguration` class was the first approach, but in order to maintain support for the existing test suite, this required keeping the existing utility method as well, thus creating a confusing interface.  It also made the accesses more verbose versus `DatadogUtilities.getDatadogGlobalDescriptor()`.

### Possible Drawbacks

Maintaining the try/catch and returning null in some scenarios can hide some potential errors since the other utility methods that check for null return default values which may not be expected and would be hard to troubleshoot.

### Verification Process

`mvn test`

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

