### PR TITLE
Re-order configuration loading logic

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -100,8 +100,8 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
 
     @DataBoundConstructor
     public DatadogGlobalConfiguration() {
-        loadEnvVariables(); // Load environment variables
         load(); // Load the persisted global configuration
+        loadEnvVariables(); // Load environment variables after as they should take precedence.
     }
 
     private void loadEnvVariables(){


### PR DESCRIPTION
See: https://github.com/jenkinsci/datadog-plugin/issues/86

Environment variables should take precedence over the locally saved configuration