### PR TITLE
Remove the result tag from the service check

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ NOTE: `event_type` is always set to `security` for above events and metrics.
 
 ### Service checks
 
-Build status `jenkins.job.status` with the default tags: : `jenkins_url`, `job`, `node`, `result`, `user_id`
+Build status `jenkins.job.status` with the default tags: : `jenkins_url`, `job`, `node`, `user_id`
 
 ## Issue Tracking
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
@@ -191,7 +191,11 @@ public class DatadogBuildListener extends RunListener<Run> {
             } else if (Result.FAILURE.toString().equals(buildResult)) {
                 status = DatadogClient.Status.CRITICAL;
             }
-            client.serviceCheck("jenkins.job.status", status, hostname, tags);
+            // Get all tags from buildData except the result tag that is used as the SC status.
+            Map<String, Set<String>> serviceCheckTags = buildData.getTags();
+            serviceCheckTags.remove("result");
+
+            client.serviceCheck("jenkins.job.status", status, hostname, serviceCheckTags);
 
             if (run.getResult() == Result.SUCCESS) {
                 long mttr = getMeanTimeToRecovery(run);

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListenerTest.java
@@ -113,42 +113,37 @@ public class DatadogBuildListenerTest {
                 124000L, 4, previousFailedRun2, 4000000L, null);
 
         datadogBuildListener.onCompleted(previousSuccessfulRun, mock(TaskListener.class));
-        String[] expectedTags1 = new String[6];
-        expectedTags1[0] = "job:ParentFullName/JobName";
-        expectedTags1[1] = "node:test-node";
-        expectedTags1[2] = "result:SUCCESS";
-        expectedTags1[3] = "user_id:anonymous";
-        expectedTags1[4] = "jenkins_url:unknown";
-        expectedTags1[5] = "branch:test-branch";
-        client.assertMetric("jenkins.job.duration", 121, "test-hostname-2", expectedTags1);
-        client.assertMetric("jenkins.job.leadtime", 121, "test-hostname-2", expectedTags1);
-        client.assertServiceCheck("jenkins.job.status", 0, "test-hostname-2", expectedTags1);
+        String[] scExpectedTags1 = new String[]{
+            "job:ParentFullName/JobName", "node:test-node", "user_id:anonymous", "jenkins_url:unknown", "branch:test-branch"
+        };
+        String[] metricExpectedTags1 = new String[6];
+        System.arraycopy(scExpectedTags1, 0, metricExpectedTags1, 0, 5);
+        metricExpectedTags1[5] = "result:SUCCESS";
+        client.assertMetric("jenkins.job.duration", 121, "test-hostname-2", metricExpectedTags1);
+        client.assertMetric("jenkins.job.leadtime", 121, "test-hostname-2", metricExpectedTags1);
+        client.assertServiceCheck("jenkins.job.status", 0, "test-hostname-2", scExpectedTags1);
 
         datadogBuildListener.onCompleted(previousFailedRun1, mock(TaskListener.class));
-        String[] expectedTags2 = new String[6];
-        expectedTags2[0] = "job:ParentFullName/JobName";
-        expectedTags2[1] = "node:test-node";
-        expectedTags2[2] = "result:FAILURE";
-        expectedTags2[3] = "user_id:anonymous";
-        expectedTags2[4] = "jenkins_url:unknown";
-        expectedTags2[5] = "branch:test-branch";
-        client.assertMetric("jenkins.job.duration", 122, "test-hostname-2", expectedTags2);
-        client.assertMetric("jenkins.job.feedbacktime", 122, "test-hostname-2", expectedTags2);
-        client.assertServiceCheck("jenkins.job.status", 2, "test-hostname-2", expectedTags2);
+        String[] metricExpectedTags2 = new String[6];
+        System.arraycopy(scExpectedTags1, 0, metricExpectedTags2, 0, 5);
+        metricExpectedTags2[5] = "result:FAILURE";
+        client.assertMetric("jenkins.job.duration", 122, "test-hostname-2", metricExpectedTags2);
+        client.assertMetric("jenkins.job.feedbacktime", 122, "test-hostname-2", metricExpectedTags2);
+        client.assertServiceCheck("jenkins.job.status", 2, "test-hostname-2", scExpectedTags1);
 
         datadogBuildListener.onCompleted(previousFailedRun2, mock(TaskListener.class));
-        client.assertMetric("jenkins.job.duration", 123, "test-hostname-2", expectedTags2);
-        client.assertMetric("jenkins.job.feedbacktime", 123, "test-hostname-2", expectedTags2);
-        client.assertMetric("jenkins.job.completed", 2, "test-hostname-2", expectedTags2);
-        client.assertServiceCheck("jenkins.job.status", 2, "test-hostname-2", expectedTags2);
+        client.assertMetric("jenkins.job.duration", 123, "test-hostname-2", metricExpectedTags2);
+        client.assertMetric("jenkins.job.feedbacktime", 123, "test-hostname-2", metricExpectedTags2);
+        client.assertMetric("jenkins.job.completed", 2, "test-hostname-2", metricExpectedTags2);
+        client.assertServiceCheck("jenkins.job.status", 2, "test-hostname-2", scExpectedTags1);
 
         datadogBuildListener.onCompleted(successRun, mock(TaskListener.class));
-        client.assertMetric("jenkins.job.duration", 124, "test-hostname-2", expectedTags1);
-        client.assertMetric("jenkins.job.leadtime", 2124, "test-hostname-2", expectedTags1);
-        client.assertMetric("jenkins.job.cycletime", (4000+124)-(1000+121), "test-hostname-2", expectedTags1);
-        client.assertMetric("jenkins.job.mttr", 4000-2000, "test-hostname-2", expectedTags1);
-        client.assertServiceCheck("jenkins.job.status", 0, "test-hostname-2", expectedTags1);
-        client.assertMetric("jenkins.job.completed", 2, "test-hostname-2", expectedTags1);
+        client.assertMetric("jenkins.job.duration", 124, "test-hostname-2", metricExpectedTags1);
+        client.assertMetric("jenkins.job.leadtime", 2124, "test-hostname-2", metricExpectedTags1);
+        client.assertMetric("jenkins.job.cycletime", (4000+124)-(1000+121), "test-hostname-2", metricExpectedTags1);
+        client.assertMetric("jenkins.job.mttr", 4000-2000, "test-hostname-2", metricExpectedTags1);
+        client.assertServiceCheck("jenkins.job.status", 0, "test-hostname-2", scExpectedTags1);
+        client.assertMetric("jenkins.job.completed", 2, "test-hostname-2", metricExpectedTags1);
         client.assertedAllMetricsAndServiceChecks();
     }
 
@@ -210,32 +205,27 @@ public class DatadogBuildListenerTest {
                 124000L, 2, null, 2000000L, previousSuccessfulRun);
 
         datadogBuildListener.onCompleted(previousSuccessfulRun, mock(TaskListener.class));
-        String[] expectedTags1 = new String[6];
-        expectedTags1[0] = "job:ParentFullName/JobName";
-        expectedTags1[1] = "node:test-node";
-        expectedTags1[2] = "result:SUCCESS";
-        expectedTags1[3] = "user_id:anonymous";
-        expectedTags1[4] = "jenkins_url:unknown";
-        expectedTags1[5] = "branch:test-branch";
-        client.assertMetric("jenkins.job.duration", 123, "test-hostname-2", expectedTags1);
-        client.assertMetric("jenkins.job.leadtime", 123, "test-hostname-2", expectedTags1);
-        client.assertMetric("jenkins.job.completed", 1, "test-hostname-2", expectedTags1);
-        client.assertServiceCheck("jenkins.job.status", 0, "test-hostname-2", expectedTags1);
+        String[] scExpectedTags = new String[]{
+                "job:ParentFullName/JobName", "node:test-node", "user_id:anonymous", "jenkins_url:unknown", "branch:test-branch"
+        };
+        String[] metricExpectedTags1 = new String[6];
+        System.arraycopy(scExpectedTags, 0, metricExpectedTags1, 0, 5);
+        metricExpectedTags1[5] = "result:SUCCESS";
+        client.assertMetric("jenkins.job.duration", 123, "test-hostname-2", metricExpectedTags1);
+        client.assertMetric("jenkins.job.leadtime", 123, "test-hostname-2", metricExpectedTags1);
+        client.assertMetric("jenkins.job.completed", 1, "test-hostname-2", metricExpectedTags1);
+        client.assertServiceCheck("jenkins.job.status", 0, "test-hostname-2", scExpectedTags);
         client.assertedAllMetricsAndServiceChecks();
 
         datadogBuildListener.onCompleted(failedRun, mock(TaskListener.class));
-        String[] expectedTags2 = new String[6];
-        expectedTags2[0] = "job:ParentFullName/JobName";
-        expectedTags2[1] = "node:test-node";
-        expectedTags2[2] = "result:FAILURE";
-        expectedTags2[3] = "user_id:anonymous";
-        expectedTags2[4] = "jenkins_url:unknown";
-        expectedTags2[5] = "branch:test-branch";
-        client.assertMetric("jenkins.job.duration", 124, "test-hostname-2", expectedTags2);
-        client.assertMetric("jenkins.job.mtbf", 1000, "test-hostname-2", expectedTags2);
-        client.assertMetric("jenkins.job.feedbacktime", 124, "test-hostname-2", expectedTags2);
-        client.assertMetric("jenkins.job.completed", 1, "test-hostname-2", expectedTags2);
-        client.assertServiceCheck("jenkins.job.status", 2, "test-hostname-2", expectedTags2);
+        String[] metricExpectedTags2 = new String[6];
+        System.arraycopy(scExpectedTags, 0, metricExpectedTags2, 0, 5);
+        metricExpectedTags2[5] = "result:FAILURE";
+        client.assertMetric("jenkins.job.duration", 124, "test-hostname-2", metricExpectedTags2);
+        client.assertMetric("jenkins.job.mtbf", 1000, "test-hostname-2", metricExpectedTags2);
+        client.assertMetric("jenkins.job.feedbacktime", 124, "test-hostname-2", metricExpectedTags2);
+        client.assertMetric("jenkins.job.completed", 1, "test-hostname-2", metricExpectedTags2);
+        client.assertServiceCheck("jenkins.job.status", 2, "test-hostname-2", scExpectedTags);
         client.assertedAllMetricsAndServiceChecks();
     }
 


### PR DESCRIPTION
The `jenkins.job.status` service check is currently reported with the `result` tag. This is useless as it creates two "groups" in monitor.

The first group is `jenkins.job.status` with `result:SUCCESS`. This one always report "OK" and will never trigger a monitor.
The second is `jenkins.job.status` with `result:FAILURE`. This one always report "CRITICAL" (sparsely).
The `result` tag is what should make the value of the service check.