### PR TITLE
Update readme to include jenkins hostname field

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,17 @@ To configure your Datadog Plugin, navigate to the `Manage Jenkins -> Configure S
 1. Select the radio button next to **Use Datadog API URL and Key to report to Datadog** (selected by default).
 2. Paste your [Datadog API key][4] in the `API Key` textbox on the Jenkins configuration screen.
 3. Test your Datadog API key by using the `Test Key` button on the Jenkins configuration screen directly below the API key textbox.
-4. (optional) Enter your [Datadog Log Intake URL][15] and select "Enable Log Collection" in the Advanced tab.
-5. Save your configuration.
+4. (optional) Enter the hostname of the Jenkins server in the Advanced tab to include it with the events.
+5. (optional) Enter your [Datadog Log Intake URL][15] and select "Enable Log Collection" in the Advanced tab.
+6. Save your configuration.
 
 ##### DogStatsD forwarding {#dogstatsd-forwarding-plugin}
 
 1. Select the radio button next to **Use the Datadog Agent to report to Datadog**.
 2. Specify your DogStatsD server `hostname` and `port`.
-3. (optional) Enter your Log Collection Port and configure [log collection](#log-collection) and select "Enable Log Collection" in the Advanced tab.
-4. Save your configuration.
+3. (optional) Enter the hostname of the Jenkins server in the Advanced tab to include it with the events.
+4. (optional) Enter your Log Collection Port and configure [log collection](#log-collection) and select "Enable Log Collection" in the Advanced tab.
+5. Save your configuration.
 
 #### Groovy script
 


### PR DESCRIPTION
# What does this PR do?

Add a line for configuring the Jenkins hostname.

### Description of the Change

This adds an optional step to add the hostname to the Jenkins configuration, which will ensure the host shows up properly in events, and not as unknown.

### Alternate Designs

The configuration is in Jenkins, and ingested by Datadog. 

### Possible Drawbacks


### Verification Process

This solved an event showing up as unknown.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

