### PR TITLE
fr-142 support jenkins.job.stage_completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ NOTE: `event_type` is always set to `security` for above events and metrics.
 | `jenkins.job.pause_duration`            | Pause duration of build job (in seconds).                     | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
 | `jenkins.job.started`                  | Rate of started jobs.                                          | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
 | `jenkins.job.stage_duration`           | Duration of individual stages.                                 | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
-| `jenkins.job.stage_completed`           | Rate of completed stages.                                 | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
+| `jenkins.job.stage_completed`          | Rate of completed stages.                                      | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
 | `jenkins.job.waiting`                  | Time spent waiting for job to run (in milliseconds).           | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
 | `jenkins.node.count`                   | Total number of node.                                          | `jenkins_url`                                                              |
 | `jenkins.node.offline`                 | Offline nodes count.                                           | `jenkins_url`                                                              |

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ NOTE: `event_type` is always set to `security` for above events and metrics.
 | `jenkins.job.pause_duration`            | Pause duration of build job (in seconds).                     | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
 | `jenkins.job.started`                  | Rate of started jobs.                                          | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
 | `jenkins.job.stage_duration`           | Duration of individual stages.                                 | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
+| `jenkins.job.stage_completed`           | Rate of completed stages.                                 | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
 | `jenkins.job.waiting`                  | Time spent waiting for job to run (in milliseconds).           | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
 | `jenkins.node.count`                   | Total number of node.                                          | `jenkins_url`                                                              |
 | `jenkins.node.offline`                 | Offline nodes count.                                           | `jenkins_url`                                                              |

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListener.java
@@ -104,6 +104,7 @@ public class DatadogGraphListener implements GraphListener {
             // Add custom result tag
             TagsUtil.addTagToTags(tags, "result", result);
             client.gauge("jenkins.job.stage_duration", getTime(startNode, endNode), hostname, tags);
+            client.gauge("jenkins.job.stage_completed", 1, hostname, tags);
         } catch (IOException | InterruptedException e) {
             DatadogUtilities.severe(logger, e, "Unable to submit the stage duration metric for " + getStageName(startNode));
         }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListener.java
@@ -104,7 +104,7 @@ public class DatadogGraphListener implements GraphListener {
             // Add custom result tag
             TagsUtil.addTagToTags(tags, "result", result);
             client.gauge("jenkins.job.stage_duration", getTime(startNode, endNode), hostname, tags);
-            client.gauge("jenkins.job.stage_completed", 1, hostname, tags);
+            client.incrementCounter("jenkins.job.stage_completed", hostname, tags);
         } catch (IOException | InterruptedException e) {
             DatadogUtilities.severe(logger, e, "Unable to submit the stage duration metric for " + getStageName(startNode));
         }

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
@@ -115,6 +115,7 @@ public class DatadogGraphListenerTest {
         String[] expectedTags = new String[] { "jenkins_url:" + DatadogUtilities.getJenkinsUrl(), "user_id:anonymous",
                 "stage_name:low", "job:pipeline", "parent_stage_name:medium", "stage_depth:2", "result:SUCCESS" };
         clientStub.assertMetric("jenkins.job.stage_duration", endTime - startTime, hostname, expectedTags);
+        clientStub.assertMetric("jenkins.job.stage_completed", 1, hostname, expectedTags);
     }
 
     @Test


### PR DESCRIPTION
### Requirements for Contributing to this repository

### What does this PR do?
https://github.com/jenkinsci/datadog-plugin/issues/142

### Description of the Change
Add additional metric when the stage completes
jenkins.job.stage_completed { stage_name, stage_depth, stage_parent, result }

### Alternate Designs

### Possible Drawbacks

### Verification Process
I validated this manually.
I was not able to run mvn test successfully due to other failures.

### Additional Notes

### Release Notes
There is additional metric now 
jenkins.job.stage_completed { stage_name, stage_depth, stage_parent, result }

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

