### PR TITLE
Add new plugin metrics 

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ NOTE: `event_type` is always set to `security` for above events and metrics.
 | `jenkins.node_status.count`            | If this node is present.                                       | `jenkins_url`, `node_hostname`, `node_name`, `node_label`                  |
 | `jenkins.node_status.up`               | If a given node is online, value 1. Otherwise, 0.              | `jenkins_url`, `node_hostname`, `node_name`, `node_label`                  |
 | `jenkins.plugin.count`                 | Plugins count.                                                 | `jenkins_url`                                                              |
+| `jenkins.plugin.active`                | Plugins active.                                                | `jenkins_url`                                                              |
+| `jenkins.plugin.failed`                | Plugins failed.                                                | `jenkins_url`                                                              |
+| `jenkins.plugin.inactivate`            | Plugins inactive.                                              | `jenkins_url`                                                              |
+| `jenkins.plugin.withUpdate`            | Plugins with update.                                           | `jenkins_url`                                                              |
 | `jenkins.project.count`                | Project count.                                                 | `jenkins_url`                                                              |
 | `jenkins.queue.size`                   | Queue Size.                                                    | `jenkins_url`                                                              |
 | `jenkins.queue.buildable`              | Number of Buildable item in Queue.                             | `jenkins_url`                                                              |

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/PluginData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/PluginData.java
@@ -1,0 +1,102 @@
+package org.datadog.jenkins.plugins.datadog.model;
+
+import jdk.tools.jlink.plugin.Plugin;
+
+import java.io.Serializable;
+
+public class PluginData implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private long count = 0;
+    private long failed = 0;
+    private long active = 0;
+    private long inactive = 0;
+    private long updatable = 0;
+
+    private PluginData(Builder builder) {
+        this.count = builder.count;
+        this.failed = builder.failed;
+        this.active = builder.active;
+        this.inactive = builder.inactive;
+        this.updatable = builder.updatable;
+    }
+
+    public static PluginData.Builder newBuilder() {
+        return new PluginData.Builder();
+    }
+
+    public static class Builder {
+        private long count = 0;
+        private long failed = 0;
+        private long active = 0;
+        private long inactive = 0;
+        private long updatable = 0;
+
+        private Builder() {
+        }
+
+        public Builder withCount(long count) {
+            this.count = count;
+            return this;
+        }
+
+        public Builder withFailed(long failed) {
+            this.failed = failed;
+            return this;
+        }
+
+        public Builder withActive(long active) {
+            this.active = active;
+            return this;
+        }
+
+        public Builder incrementActive() {
+            this.active++;
+            return this;
+        }
+
+        public Builder withInactive(long inactive) {
+            this.inactive = inactive;
+            return this;
+        }
+
+        public Builder incrementInactive() {
+            this.inactive++;
+            return this;
+        }
+
+        public Builder withUpdatable(long updatable) {
+            this.updatable = updatable;
+            return this;
+        }
+
+        public Builder incrementUpdatable() {
+            this.updatable++;
+            return this;
+        }
+
+        public PluginData build() {
+            return new PluginData(this);
+        }
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public long getFailed() {
+        return failed;
+    }
+
+    public long getActive() {
+        return active;
+    }
+
+    public long getInactive() {
+        return inactive;
+    }
+
+    public long getUpdatable() {
+        return updatable;
+    }
+}

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/PluginData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/PluginData.java
@@ -1,7 +1,5 @@
 package org.datadog.jenkins.plugins.datadog.model;
 
-import jdk.tools.jlink.plugin.Plugin;
-
 import java.io.Serializable;
 
 public class PluginData implements Serializable {


### PR DESCRIPTION

### What does this PR do?

See #155

### Description of the Change

Simply added a few new gauges for:
- jenkins.plugin.active
- jenkins.plugin.failed
- jenkins.plugin.inactivate
- jenkins.plugin.withUpdate

The data is tracked in a dto, then subsequently sent to datadog.

### Alternate Designs
N/A

### Possible Drawbacks
N/A

### Verification Process

I wasn't able to test it. For some reason I struggled to get the datadog plugin to actually send data to datadog. I tried using dogstatsd, datadog-agent and the http collector. All of them failed. I'm not really sure what else to attempt.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

Add 4 new plugin metrics:
- `jenkins.plugin.active`
- `jenkins.plugin.failed`
- `jenkins.plugin.inactivate`
- `jenkins.plugin.withUpdate`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

