### PR TITLE
Make tasklistener decorator serializable

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogConsoleLogFilter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogConsoleLogFilter.java
@@ -30,6 +30,7 @@ import hudson.console.ConsoleLogFilter;
 import hudson.model.*;
 
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
+import org.datadog.jenkins.plugins.datadog.model.BuildData;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -59,10 +60,10 @@ public class DatadogConsoleLogFilter extends ConsoleLogFilter implements Seriali
             }
 
             if (build != null) {
-                DatadogWriter writer = new DatadogWriter(build, outputStream, build.getCharset());
+                DatadogWriter writer = new DatadogWriter(new BuildData(build, null), outputStream);
                 return new DatadogOutputStream(outputStream, writer);
             } else if (run != null) {
-                DatadogWriter writer = new DatadogWriter(run, outputStream, run.getCharset());
+                DatadogWriter writer = new DatadogWriter(new BuildData(run, null), outputStream);
                 return new DatadogOutputStream(outputStream, writer);
             } else {
                 return outputStream;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogTaskListenerDecorator.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogTaskListenerDecorator.java
@@ -34,6 +34,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
+import org.datadog.jenkins.plugins.datadog.model.BuildData;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
@@ -41,16 +42,20 @@ import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
 public class DatadogTaskListenerDecorator extends TaskListenerDecorator {
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = Logger.getLogger(DatadogTaskListenerDecorator.class.getName());
-    private transient WorkflowRun run;
+    private BuildData buildData;
 
     public DatadogTaskListenerDecorator(WorkflowRun run) {
-        this.run = run;
+        try {
+            this.buildData = new BuildData(run, null);
+        } catch (Exception e) {
+            DatadogUtilities.severe(LOGGER, e, null);
+        }
     }
 
     @Nonnull
     @Override
     public OutputStream decorate(@Nonnull OutputStream outputStream) {
-        DatadogWriter writer = new DatadogWriter(run, outputStream, run.getCharset());
+        DatadogWriter writer = new DatadogWriter(this.buildData, outputStream);
         return new DatadogOutputStream(outputStream, writer);
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
@@ -45,12 +45,12 @@ public class DatadogWriter {
 
     private OutputStream errorStream;
     private Charset charset;
-    private Run<?, ?> run;
+    private BuildData buildData;
 
-    public DatadogWriter(Run<?, ?> run, OutputStream error, Charset charset) {
+    public DatadogWriter(BuildData buildData, OutputStream error) {
         this.errorStream = error != null ? error : System.err;
-        this.charset = charset;
-        this.run = run;
+        this.charset = buildData.getCharset();
+        this.buildData = buildData;
     }
 
     public Charset getCharset() {
@@ -65,8 +65,7 @@ public class DatadogWriter {
 
             JSONObject payload = new JSONObject();
 
-            BuildData buildData = new BuildData(this.run, null);
-            payload.put("ddtags", String.join(",", TagsUtil.convertTagsToArray(buildData.getTags())));
+            payload.put("ddtags", String.join(",", TagsUtil.convertTagsToArray(this.buildData.getTags())));
             payload = buildData.addLogAttributes(payload);
             payload.put("message", line);
             payload.put("ddsource", "jenkins");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -342,6 +342,8 @@ public class BuildData implements Serializable {
 
     public Charset getCharset() {
         if (charsetName != null) {
+            // Will throw an exception if there is an issue with
+            // the charset canonical name.
             return Charset.forName(charsetName);
         }
         return Charset.defaultCharset();

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -43,6 +43,7 @@ import org.datadog.jenkins.plugins.datadog.util.git.GitUtils;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +60,7 @@ public class BuildData implements Serializable {
     private String buildNumber;
     private String buildId;
     private String buildUrl;
+    private String charsetName;
     private String nodeName;
     private String jobName;
     private String buildTag;
@@ -155,6 +157,8 @@ public class BuildData implements Serializable {
         setBuildNumber(String.valueOf(run.getNumber()));
         // Set Hostname
         setHostname(DatadogUtilities.getHostname(envVars));
+        // Save charset canonical name
+        setCharset(run.getCharset());
 
         // Set Job Name
         String jobName = null;
@@ -334,6 +338,19 @@ public class BuildData implements Serializable {
 
     public void setBuildUrl(String buildUrl) {
         this.buildUrl = buildUrl;
+    }
+
+    public Charset getCharset() {
+        if (charsetName != null) {
+            return Charset.forName(charsetName);
+        }
+        return Charset.defaultCharset();
+    }
+
+    public void setCharset(Charset charset) {
+        if (charset != null) {
+            this.charsetName = charset.name();
+        }
     }
 
     public String getNodeName(String value) {

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/logs/DatadogTaskListenerDecoratorTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/logs/DatadogTaskListenerDecoratorTest.java
@@ -1,0 +1,78 @@
+/*
+The MIT License
+
+Copyright (c) 2015-Present Datadog, Inc <opensource@datadoghq.com>
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.datadog.jenkins.plugins.datadog.logs;
+
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.mockito.Mockito.*;
+
+public class DatadogTaskListenerDecoratorTest {
+    private WorkflowRun workflowRun;   
+    private WorkflowJob job; 
+
+    @Before
+    public void setupMock() {
+        workflowRun = mock(WorkflowRun.class);
+        job = mock(WorkflowJob.class);
+
+        when(job.getFullName()).thenReturn("Pipeline job");
+        when(workflowRun.getParent()).thenReturn(job);
+    }
+
+    @Test
+    public void testSerializeDeserialize() throws Exception {
+        DatadogTaskListenerDecorator datadogTaskListenerDecorator = new DatadogTaskListenerDecorator(workflowRun);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(bos);
+
+        datadogTaskListenerDecorator.decorate(System.out);
+
+        // Serialize
+        out.writeObject(datadogTaskListenerDecorator);
+        out.flush();
+        byte[] bytes = bos.toByteArray();
+        out.close(); 
+        bos.close();
+
+        ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+        ObjectInputStream in = new ObjectInputStream(bis);
+
+        // Deserialize
+        DatadogTaskListenerDecorator datadogTaskListenerDecoratorDes = (DatadogTaskListenerDecorator) in.readObject();
+        in.close();
+        bis.close();
+
+        // Assert decorate can be called
+        datadogTaskListenerDecoratorDes.decorate(System.out);
+    }
+ }


### PR DESCRIPTION
### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->
Allow `DatadogTaskListenerDecorator` to be serializable. It should prevent information loss about the Charset and fix #182 

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Jenkins sometimes serializes whole classes to send them to the jenkins agents JVM. During that process the `run` instance is null-ed (because not serializable and marked as transient). `BuildData` however is serializable, so we add the charset info to to this class, and use it instead of `WorkflowRun`.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
`Charset` is not serializable either, so we store the canonical name in `BuildData`. However it might not cover all the use cases.
Other plugins like Logstash are also relying on the canonical name only.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

