### PR TITLE
Add stage_pause_duration metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ NOTE: `event_type` is always set to `security` for above events and metrics.
 | `jenkins.job.pause_duration`            | Pause duration of build job (in seconds).                     | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
 | `jenkins.job.started`                  | Rate of started jobs.                                          | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
 | `jenkins.job.stage_duration`           | Duration of individual stages.                                 | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
+| `jenkins.job.stage_pause_duration`    | Pause duration of individual stages (in milliseconds).                          | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
 | `jenkins.job.stage_completed`          | Rate of completed stages.                                      | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
 | `jenkins.job.waiting`                  | Time spent waiting for job to run (in milliseconds).           | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
 | `jenkins.node.count`                   | Total number of node.                                          | `jenkins_url`                                                              |

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ NOTE: `event_type` is always set to `security` for above events and metrics.
 | `jenkins.job.pause_duration`            | Pause duration of build job (in seconds).                     | `branch`, `jenkins_url`, `job`, `node`, `result`, `user_id`                |
 | `jenkins.job.started`                  | Rate of started jobs.                                          | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
 | `jenkins.job.stage_duration`           | Duration of individual stages.                                 | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
-| `jenkins.job.stage_pause_duration`    | Pause duration of individual stages (in milliseconds).                          | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
+| `jenkins.job.stage_pause_duration`     | Pause duration of individual stages (in milliseconds).         | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
 | `jenkins.job.stage_completed`          | Rate of completed stages.                                      | `jenkins_url`, `job`, `user_id`, `stage_name`, `stage_depth`, `stage_parent`, `result` |
 | `jenkins.job.waiting`                  | Time spent waiting for job to run (in milliseconds).           | `branch`, `jenkins_url`, `job`, `node`, `user_id`                          |
 | `jenkins.node.count`                   | Total number of node.                                          | `jenkins_url`                                                              |

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
@@ -207,6 +207,23 @@ public class DatadogClientStub implements DatadogClient {
     }
     
     /*
+     * Returns the value of the asserted metric if it exists.
+     */
+    public double assertMetricGetValue(String name, String hostname, String[] tags) {
+        DatadogMetric m = new DatadogMetric(name, 0, hostname, Arrays.asList(tags));
+        Optional<DatadogMetric> match = this.metrics.stream().filter(t -> t.same(m)).findFirst();
+        double value = 0;
+        if (match.isPresent()) {
+            value = match.get().getValue();
+            this.metrics.remove(match.get());
+            return value;
+        }
+        Assert.fail("metric { " + m.toString() + " does not exist (ignoring value). " +
+                "metrics: {" + this.metrics.toString() + " }");
+        return value;
+    }
+
+    /*
      * Asserts that the metric of a given value is submitted a given number of times.
      */
     public boolean assertMetricValues(String name, double value, String hostname, int count) {

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
@@ -140,10 +140,10 @@ public class DatadogGraphListenerTest {
                 "job:pipelineIntegration",
                 "result:SUCCESS"
         };
-        String[] depths = new String[]{"2", "2", "2", "1", "1", "0", "0"};
-        String[] stageNames = new String[]{"Windows-1", "Windows-2", "Windows-3", "Test On Windows", "Test On Linux", "Parallel tests",
-                "Pre-setup"};
-        String[] parentNames = new String[]{"Test On Windows", "Test On Windows", "Test On Windows", "Parallel tests", "Parallel tests", "root", "root"};
+        String[] depths = new String[]{ "2", "2", "2", "1", "1", "0", "0" };
+        String[] stageNames = new String[]{ "Windows-1", "Windows-2", "Windows-3", "Test On Windows", "Test On Linux", "Parallel tests",
+                "Pre-setup" };
+        String[] parentNames = new String[]{ "Test On Windows", "Test On Windows", "Test On Windows", "Parallel tests", "Parallel tests", "root", "root" };
 
         for (int i = 0; i < depths.length; i++) {
             String[] expectedTags = Arrays.copyOf(baseTags, baseTags.length + 3);

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineDefinition.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineDefinition.txt
@@ -44,7 +44,7 @@ pipeline {
                         script {
                             try {
                                 timeout(time:11, unit:'SECONDS') {
-                                    env.TAG_ON_DOCKER_HUB = input message: 'User input required',
+                                    input message: 'User input required',
                                         parameters: [choice(name: 'Choice', choices: 'no\nyes', description: 'Choose "yes"')]
                                 }
                             } catch(err) {

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineDefinition.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineDefinition.txt
@@ -41,7 +41,16 @@ pipeline {
                         label "master"
                     }
                     steps {
-                        echo 'Linux'
+                        script {
+                            try {
+                                timeout(time:11, unit:'SECONDS') {
+                                    env.TAG_ON_DOCKER_HUB = input message: 'User input required',
+                                        parameters: [choice(name: 'Choice', choices: 'no\nyes', description: 'Choose "yes"')]
+                                }
+                            } catch(err) {
+                                echo 'Waiting over'
+                            }
+                        }
                     }
                     post {
                         always {


### PR DESCRIPTION
### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->
Add `jenkins.job.stage_pause_duration` metric. The value is the pause duration of a stage in milliseconds.
A pause can be a stage waiting for a user input.

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Each time `onNewHead` is called, it goes over the execution between `startNode` and `endNode`, to sum the pause durations of all the subnodes.
It uses the [`FlowNodeExt`](https://javadoc.jenkins.io/plugin/pipeline-rest-api/com/cloudbees/workflow/rest/external/FlowNodeExt.html) wrapper to get the pause duration of a node


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

The loops in `getPauseDuration` are needed to get the sub-node pause durations, in order to have an accurate `jenkins.job.stage_pause_duration` metric value for nested stages.

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

