### PR TITLE
Add configuration option to disable config change events

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -222,7 +222,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
             this.emitSystemEvents = Boolean.valueOf(emitSystemEventsEnvVar);
         }
 
-        String emitConfigChangeEventsEnvVar = System.getenv(EMIT_SYSTEM_EVENTS_PROPERTY);
+        String emitConfigChangeEventsEnvVar = System.getenv(EMIT_CONFIG_CHANGE_EVENTS_PROPERTY);
         if(StringUtils.isNotBlank(emitConfigChangeEventsEnvVar)){
             this.emitConfigChangeEvents = Boolean.valueOf(emitConfigChangeEventsEnvVar);
         }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -76,6 +76,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private static String GLOBAL_JOB_TAGS_PROPERTY = "DATADOG_JENKINS_PLUGIN_GLOBAL_JOB_TAGS";
     private static String EMIT_SECURITY_EVENTS_PROPERTY = "DATADOG_JENKINS_PLUGIN_EMIT_SECURITY_EVENTS";
     private static String EMIT_SYSTEM_EVENTS_PROPERTY = "DATADOG_JENKINS_PLUGIN_EMIT_SYSTEM_EVENTS";
+    private static String EMIT_CONFIG_CHANGE_EVENTS_PROPERTY = "DATADOG_JENKINS_PLUGIN_EMIT_CONFIG_CHANGE_EVENTS";
     private static String COLLECT_BUILD_LOGS_PROPERTY = "DATADOG_JENKINS_PLUGIN_COLLECT_BUILD_LOGS";
     private static String COLLECT_BUILD_TRACES_PROPERTY = "DATADOG_JENKINS_PLUGIN_COLLECT_BUILD_TRACES";
 
@@ -90,6 +91,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private static Integer DEFAULT_TARGET_LOG_COLLECTION_PORT_VALUE = null;
     private static boolean DEFAULT_EMIT_SECURITY_EVENTS_VALUE = true;
     private static boolean DEFAULT_EMIT_SYSTEM_EVENTS_VALUE = true;
+    private static boolean DEFAULT_EMIT_CONFIG_CHANGE_EVENTS_VALUE = false;
     private static boolean DEFAULT_COLLECT_BUILD_LOGS_VALUE = false;
     private static boolean DEFAULT_COLLECT_BUILD_TRACES_VALUE = false;
 
@@ -110,6 +112,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private String globalJobTags = null;
     private boolean emitSecurityEvents = DEFAULT_EMIT_SECURITY_EVENTS_VALUE;
     private boolean emitSystemEvents = DEFAULT_EMIT_SYSTEM_EVENTS_VALUE;
+    private boolean emitConfigChangeEvents = DEFAULT_EMIT_CONFIG_CHANGE_EVENTS_VALUE;
     private boolean collectBuildLogs = DEFAULT_COLLECT_BUILD_LOGS_VALUE;
     private boolean collectBuildTraces = DEFAULT_COLLECT_BUILD_TRACES_VALUE;
 
@@ -217,6 +220,11 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
         String emitSystemEventsEnvVar = System.getenv(EMIT_SYSTEM_EVENTS_PROPERTY);
         if(StringUtils.isNotBlank(emitSystemEventsEnvVar)){
             this.emitSystemEvents = Boolean.valueOf(emitSystemEventsEnvVar);
+        }
+
+        String emitConfigChangeEventsEnvVar = System.getenv(EMIT_SYSTEM_EVENTS_PROPERTY);
+        if(StringUtils.isNotBlank(emitConfigChangeEventsEnvVar)){
+            this.emitConfigChangeEvents = Boolean.valueOf(emitConfigChangeEventsEnvVar);
         }
 
         String collectBuildLogsEnvVar = System.getenv(COLLECT_BUILD_LOGS_PROPERTY);
@@ -484,6 +492,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
             this.setGlobalJobTags(formData.getString("globalJobTags"));
             this.setEmitSecurityEvents(formData.getBoolean("emitSecurityEvents"));
             this.setEmitSystemEvents(formData.getBoolean("emitSystemEvents"));
+            this.setEmitConfigChangeEvents(formData.getBoolean("emitConfigChangeEvents"));
             this.setCollectBuildLogs(formData.getBoolean("collectBuildLogs"));
 
             try {
@@ -891,6 +900,23 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     @DataBoundSetter
     public void setEmitSystemEvents(boolean emitSystemEvents) {
         this.emitSystemEvents = emitSystemEvents;
+    }
+
+    /**
+     * @return - A {@link Boolean} indicating if the user has configured Datadog to emit Config Change events.
+     */
+    public boolean isEmitConfigChangeEvents() {
+        return emitConfigChangeEvents;
+    }
+
+    /**
+     * Set the checkbox in the UI, used for Jenkins data binding
+     *
+     * @param emitConfigChangeEvents - The checkbox status (checked/unchecked)
+     */
+    @DataBoundSetter
+    public void setEmitConfigChangeEvents(boolean emitConfigChangeEvents) {
+        this.emitConfigChangeEvents = emitConfigChangeEvents;
     }
 
     /**

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSaveableListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSaveableListener.java
@@ -57,6 +57,11 @@ public class DatadogSaveableListener  extends SaveableListener {
             if (!emitSystemEvents) {
                 return;
             }
+            final boolean emitConfigChangeEvents = DatadogUtilities.getDatadogGlobalDescriptor().isEmitConfigChangeEvents();
+            if (!emitConfigChangeEvents) {
+                return;
+            }
+
             logger.fine("Start DatadogSaveableListener#onChange");
 
             // Get Datadog Client Instance

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -98,7 +98,7 @@
             <f:checkbox title="Send System events" field="emitSystemEvents" default="true" />
           </f:entry>
 
-          <f:entry description="Send events on config change.">
+          <f:entry description="Send events on config change. These events include changes by the system which may be frequent and redundant.">
             <f:checkbox title="Send Config Change events" field="emitConfigChangeEvents" default="false"/>
           </f:entry>
         </f:entry>

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -89,15 +89,21 @@
           <f:textarea field="globalJobTags" optional="true" default="${globalJobTags}" />
         </f:entry>
 
-        <f:entry description="Send security events like login, logout, login failure, configuration changes to jobs or changes to jenkins.">
+        <f:entry title="Security Events" description="Send security events like login, logout, login failure, configuration changes to jobs or changes to jenkins.">
             <f:checkbox title="Send Security audit events" field="emitSecurityEvents" default="true" />
         </f:entry>
 
-        <f:entry description="Send system events like Node changes of states.">
+        <f:entry title="System Events">
+          <f:entry description="Send system events like Node changes of states.">
             <f:checkbox title="Send System events" field="emitSystemEvents" default="true" />
+          </f:entry>
+
+          <f:entry description="Send events on config change.">
+            <f:checkbox title="Send Config Change events" field="emitConfigChangeEvents" default="false"/>
+          </f:entry>
         </f:entry>
 
-        <f:entry description="Enable Log Collection.">
+        <f:entry title="Logs" description="Enable Log Collection.">
             <f:checkbox title="Enable Log Collection" field="collectBuildLogs" default="false" />
         </f:entry>
 

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -89,7 +89,7 @@
           <f:textarea field="globalJobTags" optional="true" default="${globalJobTags}" />
         </f:entry>
 
-        <f:entry title="Security Events" description="Send security events like login, logout, login failure, configuration changes to jobs or changes to jenkins.">
+        <f:entry title="Security Events" description="Send security events like login, logout, and login failure.">
             <f:checkbox title="Send Security audit events" field="emitSecurityEvents" default="true" />
         </f:entry>
 
@@ -98,7 +98,7 @@
             <f:checkbox title="Send System events" field="emitSystemEvents" default="true" />
           </f:entry>
 
-          <f:entry description="Send events on config change. These events include changes by the system which may be frequent and redundant.">
+          <f:entry description="Send events on configuration changes to jobs or changes to jenkins. These events include changes by the system which may be frequent and redundant.">
             <f:checkbox title="Send Config Change events" field="emitConfigChangeEvents" default="false"/>
           </f:entry>
         </f:entry>


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?
Allow granular control to disable Configuration Change events.
Resolves https://github.com/jenkinsci/datadog-plugin/issues/49

### Description of the Change

This PR introduces a new configuration checkbox under System Events and disables Config Change events. 
This PR also adds a title to the Events category allowing future additional options to manage different types of events.

### Alternate Designs

### Possible Drawbacks

This will require a major release as it disables Configuration Change Events by default.
### Verification Process

1. Navigate to Advanced Configuration of Datadog plugin
2. Verify `Send Config Change events` checkbox is unchecked.
3. Observe no config change events emitted. Checking the box should start submitting events like `User <user> changed <file>`

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

