### PR TITLE
Avoid sending `jenkins.step.internal` spans

### DIFF
--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
@@ -163,14 +163,17 @@ public class DatadogGraphListenerTest {
 
         //Traces
         final ListWriter tracerWriter = clientStub.tracerWriter();
-        tracerWriter.waitForTraces(2);
-        assertEquals(2, tracerWriter.size());
+        tracerWriter.waitForTraces(3);
+        assertEquals(3, tracerWriter.size());
 
         final List<DDSpan> buildTrace = tracerWriter.get(0);
         assertEquals(1, buildTrace.size());
 
-        final List<DDSpan> pipelineTrace = tracerWriter.get(1);
-        assertEquals(34, pipelineTrace.size());
+        final List<DDSpan> stage01Trace = tracerWriter.get(1);
+        assertEquals(2, stage01Trace.size());
+
+        final List<DDSpan> stage02Trace = tracerWriter.get(2);
+        assertEquals(13, stage02Trace.size());
     }
 
     @Test
@@ -270,32 +273,20 @@ public class DatadogGraphListenerTest {
         assertEquals(1, buildTrace.size());
 
         final List<DDSpan> pipelineTrace = tracerWriter.get(1);
-        assertEquals(16, pipelineTrace.size());
+        assertEquals(5, pipelineTrace.size());
 
-        final DDSpan stage2 = pipelineTrace.get(6);
+        final DDSpan stage2 = pipelineTrace.get(1);
         final String stage2Name = (String) stage2.getTag(BuildPipelineNode.NodeType.STAGE.getTagName() + CITags._NAME);
         assertTrue(stage2Name != null && !stage2Name.isEmpty());
 
-        final DDSpan allocateNodeStart2 = pipelineTrace.get(7);
-        assertEquals(stage2Name, allocateNodeStart2.getTag(BuildPipelineNode.NodeType.STAGE.getTagName() + CITags._NAME));
-
-        final DDSpan allocateNodeBodyStart2 = pipelineTrace.get(8);
-        assertEquals(stage2Name, allocateNodeBodyStart2.getTag(BuildPipelineNode.NodeType.STAGE.getTagName() + CITags._NAME));
-
-        final DDSpan stepStage2 = pipelineTrace.get(9);
+        final DDSpan stepStage2 = pipelineTrace.get(2);
         assertEquals(stage2Name, stepStage2.getTag(BuildPipelineNode.NodeType.STAGE.getTagName() + CITags._NAME));
 
-        final DDSpan stage1 = pipelineTrace.get(12);
+        final DDSpan stage1 = pipelineTrace.get(3);
         final String stage1Name = (String) stage1.getTag(BuildPipelineNode.NodeType.STAGE.getTagName() + CITags._NAME);
         assertTrue(stage1Name != null && !stage1Name.isEmpty());
 
-        final DDSpan allocateNodeStart1 = pipelineTrace.get(13);
-        assertEquals(stage1Name, allocateNodeStart1.getTag(BuildPipelineNode.NodeType.STAGE.getTagName() + CITags._NAME));
-
-        final DDSpan allocateNodeBodyStart1 = pipelineTrace.get(14);
-        assertEquals(stage1Name, allocateNodeBodyStart1.getTag(BuildPipelineNode.NodeType.STAGE.getTagName() + CITags._NAME));
-
-        final DDSpan stepStage1 = pipelineTrace.get(15);
+        final DDSpan stepStage1 = pipelineTrace.get(4);
         assertEquals(stage1Name, stepStage1.getTag(BuildPipelineNode.NodeType.STAGE.getTagName() + CITags._NAME));
     }
 
@@ -330,56 +321,23 @@ public class DatadogGraphListenerTest {
         assertEquals(0L, buildSpan.getUnsafeMetrics().get(CITags.QUEUE_TIME));
 
         final List<DDSpan> pipelineTrace = tracerWriter.get(1);
-        assertEquals(16, pipelineTrace.size());
+        assertEquals(5, pipelineTrace.size());
 
-        final DDSpan startPipeline = pipelineTrace.get(0);
-        assertEquals(0L, startPipeline.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final DDSpan stageStart = pipelineTrace.get(1);
-        assertEquals(0L, stageStart.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final DDSpan runStages = pipelineTrace.get(2);
+        final DDSpan runStages = pipelineTrace.get(0);
         assertEquals(0L, runStages.getUnsafeMetrics().get(CITags.QUEUE_TIME));
 
-        final DDSpan executeInParallelStart = pipelineTrace.get(3);
-        assertEquals(0L, executeInParallelStart.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final DDSpan branchStage2 = pipelineTrace.get(4);
-        assertEquals(0L, branchStage2.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final DDSpan stage2Start = pipelineTrace.get(5);
-        assertEquals(0L, stage2Start.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final DDSpan stage2 = pipelineTrace.get(6);
+        final DDSpan stage2 = pipelineTrace.get(1);
         long stage2QueueTime = (long) stage2.getUnsafeMetrics().get(CITags.QUEUE_TIME);
         assertTrue(stage2QueueTime > 0L);
 
-        final DDSpan allocateNodeStart2 = pipelineTrace.get(7);
-        assertEquals(stage2QueueTime, allocateNodeStart2.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final DDSpan allocateNodeBodyStart2 = pipelineTrace.get(8);
-        assertEquals(0L, allocateNodeBodyStart2.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final DDSpan stepStage2 = pipelineTrace.get(9);
+        final DDSpan stepStage2 = pipelineTrace.get(2);
         assertEquals(0L, stepStage2.getUnsafeMetrics().get(CITags.QUEUE_TIME));
 
-        final DDSpan branchStage1 = pipelineTrace.get(10);
-        assertEquals(0L, branchStage1.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final DDSpan stage1Start = pipelineTrace.get(11);
-        assertEquals(0L, stage1Start.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final DDSpan stage1 = pipelineTrace.get(12);
+        final DDSpan stage1 = pipelineTrace.get(3);
         long stage1QueueTime = (long) stage1.getUnsafeMetrics().get(CITags.QUEUE_TIME);
         assertTrue(stage1QueueTime > 0L);
 
-        final DDSpan allocateNodeStart1 = pipelineTrace.get(13);
-        assertEquals(stage1QueueTime, allocateNodeStart1.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final DDSpan allocateNodeBodyStart1 = pipelineTrace.get(14);
-        assertEquals(0L, allocateNodeBodyStart1.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final DDSpan stepStage1 = pipelineTrace.get(15);
+        final DDSpan stepStage1 = pipelineTrace.get(4);
         assertEquals(0L, stepStage1.getUnsafeMetrics().get(CITags.QUEUE_TIME));
     }
 
@@ -421,36 +379,16 @@ public class DatadogGraphListenerTest {
         assertEquals("none",buildSpan.getTag(CITags._DD_HOSTNAME));
 
         final List<DDSpan> pipelineTrace = tracerWriter.get(1);
-        assertEquals(6, pipelineTrace.size());
+        assertEquals(2, pipelineTrace.size());
         assertEquals("testPipeline", buildSpan.getTag(CITags.NODE_NAME));
         assertEquals("none",buildSpan.getTag(CITags._DD_HOSTNAME));
 
-        final DDSpan startPipeline = pipelineTrace.get(0);
-        assertEquals(queueTime, startPipeline.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-        assertEquals("testPipeline", buildSpan.getTag(CITags.NODE_NAME));
-        assertEquals("none",buildSpan.getTag(CITags._DD_HOSTNAME));
-
-        final DDSpan allocateNode = pipelineTrace.get(1);
-        assertEquals(queueTime, allocateNode.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-        assertEquals("testPipeline", buildSpan.getTag(CITags.NODE_NAME));
-        assertEquals("none",buildSpan.getTag(CITags._DD_HOSTNAME));
-
-        final DDSpan allocateNodeStart = pipelineTrace.get(2);
-        assertEquals(0L, allocateNodeStart.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-        assertEquals("testPipeline", buildSpan.getTag(CITags.NODE_NAME));
-        assertEquals("none",buildSpan.getTag(CITags._DD_HOSTNAME));
-
-        final DDSpan stageStart = pipelineTrace.get(3);
-        assertEquals(0L, stageStart.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-        assertEquals("testPipeline", buildSpan.getTag(CITags.NODE_NAME));
-        assertEquals("none",buildSpan.getTag(CITags._DD_HOSTNAME));
-
-        final DDSpan stage = pipelineTrace.get(4);
+        final DDSpan stage = pipelineTrace.get(0);
         assertEquals(0L, stage.getUnsafeMetrics().get(CITags.QUEUE_TIME));
         assertEquals("testPipeline", buildSpan.getTag(CITags.NODE_NAME));
         assertEquals("none",buildSpan.getTag(CITags._DD_HOSTNAME));
 
-        final DDSpan step = pipelineTrace.get(5);
+        final DDSpan step = pipelineTrace.get(1);
         assertEquals(0L, step.getUnsafeMetrics().get(CITags.QUEUE_TIME));
         assertEquals("testPipeline", buildSpan.getTag(CITags.NODE_NAME));
         assertEquals("none",buildSpan.getTag(CITags._DD_HOSTNAME));
@@ -511,51 +449,10 @@ public class DatadogGraphListenerTest {
         assertTrue(((String) buildSpan.getTag(CITags._DD_CI_STAGES)).contains("{\"name\":\"test\",\"duration\""));
 
         final List<DDSpan> pipelineTrace = tracerWriter.get(1);
-        assertEquals(4, pipelineTrace.size());
-
-        final String pipelinePrefix = BuildPipelineNode.NodeType.STEP.getTagName();
-        final DDSpan pipelineSpan = pipelineTrace.get(0);
-        assertEquals("jenkins.step.internal", pipelineSpan.getOperationName());
-        assertEquals(SAMPLE_SERVICE_NAME, pipelineSpan.getServiceName());
-        assertEquals("Start of Pipeline", pipelineSpan.getResourceName());
-        assertEquals("ci", pipelineSpan.getType());
-        assertEquals("Start of Pipeline", pipelineSpan.getTag(pipelinePrefix + CITags._NAME));
-        assertEquals("2", pipelineSpan.getTag(pipelinePrefix + CITags._NUMBER));
-        assertEquals("success", pipelineSpan.getTag(CITags.JENKINS_RESULT));
-        assertEquals("jenkins", pipelineSpan.getTag(CITags.CI_PROVIDER_NAME));
-        assertNotNull(pipelineSpan.getTag(pipelinePrefix + CITags._URL));
-        assertNotNull(pipelineSpan.getTag(CITags.NODE_NAME));
-        assertNull(pipelineSpan.getTag(CITags._DD_HOSTNAME));
-        assertEquals(true, pipelineSpan.getTag(CITags._DD_CI_INTERNAL));
-        assertNull(pipelineSpan.getTag(CITags._DD_CI_BUILD_LEVEL));
-        assertNull(pipelineSpan.getTag(CITags._DD_CI_LEVEL));
-        assertEquals("jenkins-pipelineIntegrationSuccess-1", pipelineSpan.getTag(BuildPipelineNode.NodeType.PIPELINE.getTagName() + CITags._ID));
-        assertEquals("pipelineIntegrationSuccess", pipelineSpan.getTag(BuildPipelineNode.NodeType.PIPELINE.getTagName() + CITags._NAME));
-        assertNotNull(pipelineSpan.getUnsafeMetrics().get(CITags.QUEUE_TIME));
-
-        final String stepPrefix = BuildPipelineNode.NodeType.STEP.getTagName();
-        final DDSpan stepInternalSpan = pipelineTrace.get(1);
-        assertEquals("jenkins.step.internal", stepInternalSpan.getOperationName());
-        assertEquals(SAMPLE_SERVICE_NAME, stepInternalSpan.getServiceName());
-        assertEquals("Stage : Start", stepInternalSpan.getResourceName());
-        assertEquals("ci", stepInternalSpan.getType());
-        assertEquals("Stage : Start", stepInternalSpan.getTag(stepPrefix + CITags._NAME));
-        assertEquals("success", stepInternalSpan.getTag(CITags.JENKINS_RESULT));
-        assertEquals("jenkins", stepInternalSpan.getTag(CITags.CI_PROVIDER_NAME));
-        assertEquals("test", stepInternalSpan.getTag("jenkins.step.args.name"));
-        assertNotNull(stepInternalSpan.getTag(stepPrefix + CITags._URL));
-        assertNotNull(stepInternalSpan.getTag(CITags.NODE_NAME));
-        assertNull(stepInternalSpan.getTag(CITags._DD_HOSTNAME));
-        assertEquals(true, stepInternalSpan.getTag(CITags._DD_CI_INTERNAL));
-        assertEquals("3", stepInternalSpan.getTag(stepPrefix + CITags._NUMBER));
-        assertNull(stepInternalSpan.getTag(CITags._DD_CI_BUILD_LEVEL));
-        assertNull(stepInternalSpan.getTag(CITags._DD_CI_LEVEL));
-        assertEquals("jenkins-pipelineIntegrationSuccess-1", stepInternalSpan.getTag(BuildPipelineNode.NodeType.PIPELINE.getTagName() + CITags._ID));
-        assertEquals("pipelineIntegrationSuccess", stepInternalSpan.getTag(BuildPipelineNode.NodeType.PIPELINE.getTagName() + CITags._NAME));
-        assertNotNull(stepInternalSpan.getUnsafeMetrics().get(CITags.QUEUE_TIME));
+        assertEquals(2, pipelineTrace.size());
 
         final String stagePrefix = BuildPipelineNode.NodeType.STAGE.getTagName();
-        final DDSpan stageSpan = pipelineTrace.get(2);
+        final DDSpan stageSpan = pipelineTrace.get(0);
         assertEquals("jenkins.stage", stageSpan.getOperationName());
         assertEquals(SAMPLE_SERVICE_NAME, stageSpan.getServiceName());
         assertEquals("test", stageSpan.getResourceName());
@@ -574,7 +471,8 @@ public class DatadogGraphListenerTest {
         assertEquals("pipelineIntegrationSuccess", stageSpan.getTag(BuildPipelineNode.NodeType.PIPELINE.getTagName() + CITags._NAME));
         assertNotNull(stageSpan.getUnsafeMetrics().get(CITags.QUEUE_TIME));
 
-        final DDSpan stepAtomSpan = pipelineTrace.get(3);
+        final String stepPrefix = BuildPipelineNode.NodeType.STEP.getTagName();
+        final DDSpan stepAtomSpan = pipelineTrace.get(1);
         assertEquals("jenkins.step", stepAtomSpan.getOperationName());
         assertEquals(SAMPLE_SERVICE_NAME, stepAtomSpan.getServiceName());
         assertEquals("Print Message", stepAtomSpan.getResourceName());


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

We've received feedback from alpha customers saying `jenkins.step.internal` spans are not so much useful. 
Additionally, we want to reduce the complexity of recalculating the trace tree when we tackle the issue of removing the queue time from the relevant span duration.

This PR modifies the algorithm that sends the spans of the Jenkins pipelines to avoid sending the `jenkins.step.internal` spans.


### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Added an additional condition in the `isTraceable` method checking if the node is internal or not. If it's internal, the span is not sent and the algorithm continues with its children.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

