### PR TITLE
Fix `StepData` override in `DatadogStepListener` for Jenkins Pipelines traces

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogStepListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogStepListener.java
@@ -5,6 +5,7 @@ import hudson.model.Run;
 import org.datadog.jenkins.plugins.datadog.model.StepData;
 import org.datadog.jenkins.plugins.datadog.traces.StepDataAction;
 import org.jenkinsci.plugins.workflow.flow.StepListener;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
@@ -26,7 +27,15 @@ public class DatadogStepListener implements StepListener {
                 return;
             }
 
-            stepDataAction.put(step.getDescriptor(), new StepData(context));
+            final FlowNode flowNode = context.get(FlowNode.class);
+            if(flowNode == null) {
+                logger.severe("Unable to store Step data in Run '"+run.getFullDisplayName()+"'. FlowNode is null");
+                return;
+            }
+
+            final StepData stepData = new StepData(context);
+            stepDataAction.put(flowNode, stepData);
+
         } catch (Exception ex) {
             logger.severe("Unable to extract Run information of the StepContext. " + ex);
         }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
@@ -124,7 +124,7 @@ public class BuildPipelineNode {
         this.args = ArgumentsAction.getFilteredArguments(startNode);
 
         if(endNode instanceof StepNode){
-            final StepData stepData = getStepData(endNode);
+            final StepData stepData = getStepData(startNode);
             if(stepData != null) {
                 this.envVars = stepData.getEnvVars();
                 this.workspace = stepData.getWorkspace();
@@ -391,20 +391,20 @@ public class BuildPipelineNode {
     }
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
-    private StepData getStepData(final FlowNode node) {
-        final Run<?, ?> run = getRun(node);
+    private StepData getStepData(final FlowNode flowNode) {
+        final Run<?, ?> run = getRun(flowNode);
         if(run == null) {
-            logger.fine("Unable to get StepData from node '"+node.getDisplayName()+"'. Run is null");
+            logger.fine("Unable to get StepData from flowNode '"+flowNode.getDisplayName()+"'. Run is null");
             return null;
         }
 
         final StepDataAction stepDataAction = run.getAction(StepDataAction.class);
         if(stepDataAction == null) {
-            logger.fine("Unable to get StepData from node '"+node.getDisplayName()+"'. StepDataAction is null");
+            logger.fine("Unable to get StepData from flowNode '"+flowNode.getDisplayName()+"'. StepDataAction is null");
             return null;
         }
 
-        return stepDataAction.get(((StepNode) node).getDescriptor());
+        return stepDataAction.get(flowNode);
     }
 
     private FlowNodeQueueData getQueueData(FlowNode node) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/StepDataAction.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/StepDataAction.java
@@ -2,6 +2,7 @@ package org.datadog.jenkins.plugins.datadog.traces;
 
 import hudson.model.InvisibleAction;
 import org.datadog.jenkins.plugins.datadog.model.StepData;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 
 import java.io.Serializable;
@@ -17,12 +18,12 @@ public class StepDataAction extends InvisibleAction implements Serializable {
 
     private final Map<String, StepData> stepDataByDescriptor = new HashMap<>();
 
-    public StepData put(final StepDescriptor descriptor, final StepData stepData) {
-        return stepDataByDescriptor.put(descriptor.toString(), stepData);
+    public StepData put(final FlowNode flowNode, final StepData stepData) {
+        return stepDataByDescriptor.put(flowNode.getId(), stepData);
     }
 
-    public StepData get(final StepDescriptor descriptor) {
-        return stepDataByDescriptor.get(descriptor.toString());
+    public StepData get(final FlowNode flowNode) {
+        return stepDataByDescriptor.get(flowNode.getId());
     }
 
 }


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Using the `DatadogStepListener` class, we're collecting information associated with the actual `Step` is being executed at that moment, such as environment variables, node name, etc.. in a `StepData` instance. Every `StepData` instance is kept in a map that will be accessed at the end of the pipeline execution to create the trace.

Currently, the key of the map is based on the `StepDescriptor`, but Jenkins is reusing the same descriptor for different steps (e.g. the step descriptor of the step representing the Git checkout is the same across the pipeline execution).

This PR changes the key of the map to use the `FlowNode` IDs, which are uniques during a certain `Run`. 

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

The `StepData` map uses the  `FlowNode` id (unique) instead of the `StepDescriptor` in the `DatadogStepListener` class.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

