### PR TITLE
Remove queue time from spans duration on Jenkins traces

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
@@ -145,12 +145,12 @@ public class DatadogBuildListener extends RunListener<Run> {
             Map<String, Set<String>> tags = buildData.getTags();
             String hostname = buildData.getHostname("unknown");
             try {
-                long waiting = (DatadogUtilities.currentTimeMillis() - item.getInQueueSince()) / 1000;
-                client.gauge("jenkins.job.waiting", waiting, hostname, tags);
+                long waitingMs = (DatadogUtilities.currentTimeMillis() - item.getInQueueSince());
+                client.gauge("jenkins.job.waiting", TimeUnit.MILLISECONDS.toSeconds(waitingMs), hostname, tags);
 
                 final BuildSpanAction buildSpanAction = run.getAction(BuildSpanAction.class);
                 if(buildSpanAction != null && buildSpanAction.getBuildData() != null) {
-                    buildSpanAction.getBuildData().setSecondsInQueue(waiting);
+                    buildSpanAction.getBuildData().setMillisInQueue(waitingMs);
                 }
             } catch (NullPointerException e) {
                 logger.warning("Unable to compute 'waiting' metric. " +

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogQueueListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogQueueListener.java
@@ -64,10 +64,10 @@ public class DatadogQueueListener extends QueueListener {
 
             final FlowNodeQueueData flowNodeData = queueAction.get(flowNode.getId());
             if(flowNodeData != null) {
-                flowNodeData.setEnterBuildable(System.currentTimeMillis());
+                flowNodeData.setEnterBuildableNanos(System.nanoTime());
             } else {
                 final FlowNodeQueueData data = new FlowNodeQueueData(flowNode.getId());
-                data.setEnterBuildable(System.currentTimeMillis());
+                data.setEnterBuildableNanos(System.nanoTime());
                 queueAction.put(flowNode.getId(), data);
             }
 
@@ -113,7 +113,7 @@ public class DatadogQueueListener extends QueueListener {
 
             final FlowNodeQueueData flowNodeData = queueAction.get(flowNode.getId());
             if(flowNodeData != null) {
-                flowNodeData.setLeaveBuildable(System.currentTimeMillis());
+                flowNodeData.setLeaveBuildableNanos(System.nanoTime());
             }
         } catch (Exception e){
             logger.severe("Error onLeaveBuildable: item:" + item + ", exception: " + e);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -104,6 +104,8 @@ public class BuildData implements Serializable {
     private Long duration;
     private Long secondsInQueue;
     private Long propagatedSecondsInQueue;
+    private Long millisInQueue;
+    private Long propagatedMillisInQueue;
 
     private String traceId;
     private String spanId;
@@ -403,20 +405,20 @@ public class BuildData implements Serializable {
         this.startTime = startTime;
     }
 
-    public Long getSecondsInQueue(Long value) {
-        return defaultIfNull(secondsInQueue, value);
+    public Long getMillisInQueue(Long value) {
+        return defaultIfNull(millisInQueue, value);
     }
 
-    public void setSecondsInQueue(Long secondsInQueue) {
-        this.secondsInQueue = secondsInQueue;
+    public void setMillisInQueue(Long millisInQueue) {
+        this.millisInQueue = millisInQueue;
     }
 
-    public Long getPropagatedSecondsInQueue(Long value) {
-        return defaultIfNull(propagatedSecondsInQueue, value);
+    public Long getPropagatedMillisInQueue(Long value) {
+        return defaultIfNull(propagatedMillisInQueue, value);
     }
 
-    public void setPropagatedSecondsInQueue(Long propagatedSecondsInQueue) {
-        this.propagatedSecondsInQueue = propagatedSecondsInQueue;
+    public void setPropagatedMillisInQueue(Long propagatedMillisInQueue) {
+        this.propagatedMillisInQueue = propagatedMillisInQueue;
     }
 
     public String getBuildId(String value) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipeline.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipeline.java
@@ -122,7 +122,7 @@ public class BuildPipeline {
             if((node.isInitial() || BuildPipelineNode.NodeType.STAGE.equals(node.getType())) && node.getChildren().size() == 1){
                 BuildPipelineNode child = node.getChildren().get(0);
                 if(child.getName().contains("Allocate node")) {
-                    node.setPropagatedSecondsInQueue(child.getSecondsInQueue());
+                    node.setPropagatedNanosInQueue(child.getNanosInQueue());
                 }
             }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
@@ -73,8 +73,8 @@ public class BuildPipelineNode {
     private long startTimeMicros;
     private long endTime;
     private long endTimeMicros;
-    private long secondsInQueue = -1L;
-    private long propagatedSecondsInQueue = -1L;
+    private long nanosInQueue = -1L;
+    private long propagatedNanosInQueue = -1L;
     private String result;
 
     // Flag that indicates if the node must be marked as error.
@@ -135,7 +135,7 @@ public class BuildPipelineNode {
 
         final FlowNodeQueueData queueData = getQueueData(startNode);
         if(queueData != null) {
-            this.secondsInQueue = queueData.getSecondsInQueue();
+            this.nanosInQueue = queueData.getNanosInQueue();
         }
 
         this.logText = getLogText(endNode);
@@ -170,7 +170,7 @@ public class BuildPipelineNode {
 
         final FlowNodeQueueData queueData = getQueueData(stepNode);
         if(queueData != null) {
-            this.secondsInQueue = queueData.getSecondsInQueue();
+            this.nanosInQueue = queueData.getNanosInQueue();
         }
 
         this.logText = getLogText(stepNode);
@@ -254,8 +254,8 @@ public class BuildPipelineNode {
         return endTimeMicros;
     }
 
-    public long getSecondsInQueue() {
-        return secondsInQueue;
+    public long getNanosInQueue() {
+        return nanosInQueue;
     }
 
     public void setEndTime(long endTime) {
@@ -263,16 +263,16 @@ public class BuildPipelineNode {
         this.endTimeMicros = this.endTime * 1000;
     }
 
-    public void setSecondsInQueue(long secondsInQueue) {
-        this.secondsInQueue = secondsInQueue;
+    public void setNanosInQueue(long nanosInQueue) {
+        this.nanosInQueue = nanosInQueue;
     }
 
-    public long getPropagatedSecondsInQueue() {
-        return propagatedSecondsInQueue;
+    public long getPropagatedNanosInQueue() {
+        return propagatedNanosInQueue;
     }
 
-    public void setPropagatedSecondsInQueue(long propagatedSecondsInQueue) {
-        this.propagatedSecondsInQueue = propagatedSecondsInQueue;
+    public void setPropagatedNanosInQueue(long propagatedNanosInQueue) {
+        this.propagatedNanosInQueue = propagatedNanosInQueue;
     }
 
     public String getResult() {
@@ -327,7 +327,7 @@ public class BuildPipelineNode {
         this.startTimeMicros = buildNode.startTimeMicros;
         this.endTime = buildNode.endTime;
         this.endTimeMicros = buildNode.endTimeMicros;
-        this.secondsInQueue = buildNode.secondsInQueue;
+        this.nanosInQueue = buildNode.nanosInQueue;
         this.result = buildNode.result;
         this.error = buildNode.error;
         this.errorObj = buildNode.errorObj;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
@@ -260,7 +261,7 @@ public class BuildPipelineNode {
 
     public void setEndTime(long endTime) {
         this.endTime = endTime;
-        this.endTimeMicros = this.endTime * 1000;
+        this.endTimeMicros = TimeUnit.MILLISECONDS.toMicros(this.endTime);
     }
 
     public void setNanosInQueue(long nanosInQueue) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/FlowNodeQueueData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/FlowNodeQueueData.java
@@ -11,31 +11,34 @@ public class FlowNodeQueueData implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final String nodeId;
-    private long enterBuildable;
-    private long leaveBuildable;
+    private long enterBuildableNanos;
+    private long leaveBuildableNanos;
+    private long queueTimeNanos = -1L;
 
     public FlowNodeQueueData(final String nodeId) {
         this.nodeId = nodeId;
     }
 
-    public void setEnterBuildable(long timestamp) {
-        this.enterBuildable = timestamp;
+    public void setEnterBuildableNanos(long timestampNanos) {
+        this.enterBuildableNanos = timestampNanos;
     }
 
-    public void setLeaveBuildable(long timestamp) {
-        this.leaveBuildable = timestamp;
+    public void setLeaveBuildableNanos(long timestampNanos) {
+        this.leaveBuildableNanos = timestampNanos;
+        this.queueTimeNanos = this.leaveBuildableNanos - this.enterBuildableNanos;
     }
 
-    public long getSecondsInQueue() {
-        return TimeUnit.MILLISECONDS.toSeconds(this.leaveBuildable - enterBuildable);
+    public long getNanosInQueue() {
+        return this.queueTimeNanos;
     }
 
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("FlowNodeQueueData{");
-        sb.append("nodeId=").append(nodeId);
-        sb.append(", enterBuildable=").append(enterBuildable);
-        sb.append(", leaveBuildable=").append(leaveBuildable);
+        sb.append("nodeId='").append(nodeId).append('\'');
+        sb.append(", enterBuildableNanos=").append(enterBuildableNanos);
+        sb.append(", leaveBuildableNanos=").append(leaveBuildableNanos);
+        sb.append(", queueTimeNanos=").append(queueTimeNanos);
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
@@ -100,7 +100,7 @@ public class DatadogTraceBuildLogic {
         // BuildSpanAction has been updated by the information available
         // inside the Pipeline steps. (Only applicable if the build is
         // based on Jenkins Pipelines).
-        final BuildData pipelineData = buildSpanAction.getBuildData();
+        final BuildData updatedBuildData = buildSpanAction.getBuildData();
 
         final String prefix = BuildPipelineNode.NodeType.PIPELINE.getTagName();
         final String buildLevel = BuildPipelineNode.NodeType.PIPELINE.getBuildLevel();
@@ -117,13 +117,13 @@ public class DatadogTraceBuildLogic {
         buildSpan.setTag(prefix + CITags._NUMBER, buildData.getBuildNumber(""));
         buildSpan.setTag(prefix + CITags._URL, buildData.getBuildUrl(""));
         if (buildSpan instanceof MutableSpan) {
-            ((MutableSpan) buildSpan).setMetric(CITags.QUEUE_TIME, TimeUnit.MILLISECONDS.toSeconds(getMillisInQueue(buildData, pipelineData)));
+            ((MutableSpan) buildSpan).setMetric(CITags.QUEUE_TIME, TimeUnit.MILLISECONDS.toSeconds(getMillisInQueue(updatedBuildData)));
         }
 
-        final String workspace = buildData.getWorkspace("").isEmpty() ? pipelineData.getWorkspace("") : buildData.getWorkspace("");
+        final String workspace = buildData.getWorkspace("").isEmpty() ? updatedBuildData.getWorkspace("") : buildData.getWorkspace("");
         buildSpan.setTag(CITags.WORKSPACE_PATH, workspace);
 
-        final String nodeName = buildData.getNodeName("").isEmpty() ? pipelineData.getNodeName("") : buildData.getNodeName("");
+        final String nodeName = buildData.getNodeName("").isEmpty() ? updatedBuildData.getNodeName("") : buildData.getNodeName("");
 
         buildSpan.setTag(CITags.NODE_NAME, nodeName);
         // If the NodeName == master, we don't set _dd.hostname. It will be overridden by the Datadog Agent. (Traces are only available using Datadog Agent)
@@ -133,38 +133,38 @@ public class DatadogTraceBuildLogic {
         }
 
         // Git Info
-        final String gitUrl = buildData.getGitUrl("").isEmpty() ? pipelineData.getGitUrl("") : buildData.getGitUrl("");
+        final String gitUrl = buildData.getGitUrl("").isEmpty() ? updatedBuildData.getGitUrl("") : buildData.getGitUrl("");
         buildSpan.setTag(CITags.GIT_REPOSITORY_URL, gitUrl);
 
-        final String gitCommit = buildData.getGitCommit("").isEmpty() ? pipelineData.getGitCommit("") : buildData.getGitCommit("");
+        final String gitCommit = buildData.getGitCommit("").isEmpty() ? updatedBuildData.getGitCommit("") : buildData.getGitCommit("");
         buildSpan.setTag(CITags.GIT_COMMIT__SHA, gitCommit); //Maintain retrocompatibility
         buildSpan.setTag(CITags.GIT_COMMIT_SHA, gitCommit);
 
-        final String gitMessage = buildData.getGitMessage("").isEmpty() ? pipelineData.getGitMessage("") : buildData.getGitMessage("");
+        final String gitMessage = buildData.getGitMessage("").isEmpty() ? updatedBuildData.getGitMessage("") : buildData.getGitMessage("");
         buildSpan.setTag(CITags.GIT_COMMIT_MESSAGE, gitMessage);
 
-        final String gitAuthor = buildData.getGitAuthorName("").isEmpty() ? pipelineData.getGitAuthorName("") : buildData.getGitAuthorName("");
+        final String gitAuthor = buildData.getGitAuthorName("").isEmpty() ? updatedBuildData.getGitAuthorName("") : buildData.getGitAuthorName("");
         buildSpan.setTag(CITags.GIT_COMMIT_AUTHOR_NAME, gitAuthor);
 
-        final String gitAuthorEmail = buildData.getGitAuthorEmail("").isEmpty() ? pipelineData.getGitAuthorEmail("") : buildData.getGitAuthorEmail("");
+        final String gitAuthorEmail = buildData.getGitAuthorEmail("").isEmpty() ? updatedBuildData.getGitAuthorEmail("") : buildData.getGitAuthorEmail("");
         buildSpan.setTag(CITags.GIT_COMMIT_AUTHOR_EMAIL, gitAuthorEmail);
 
-        final String gitAuthorDate = buildData.getGitAuthorDate("").isEmpty() ? pipelineData.getGitAuthorDate("") : buildData.getGitAuthorDate("");
+        final String gitAuthorDate = buildData.getGitAuthorDate("").isEmpty() ? updatedBuildData.getGitAuthorDate("") : buildData.getGitAuthorDate("");
         buildSpan.setTag(CITags.GIT_COMMIT_AUTHOR_DATE, gitAuthorDate);
 
-        final String gitCommitter = buildData.getGitCommitterName("").isEmpty() ? pipelineData.getGitCommitterName("") : buildData.getGitCommitterName("");
+        final String gitCommitter = buildData.getGitCommitterName("").isEmpty() ? updatedBuildData.getGitCommitterName("") : buildData.getGitCommitterName("");
         buildSpan.setTag(CITags.GIT_COMMIT_COMMITTER_NAME, gitCommitter);
 
-        final String gitCommitterEmail = buildData.getGitCommitterEmail("").isEmpty() ? pipelineData.getGitCommitterEmail("") : buildData.getGitCommitterEmail("");
+        final String gitCommitterEmail = buildData.getGitCommitterEmail("").isEmpty() ? updatedBuildData.getGitCommitterEmail("") : buildData.getGitCommitterEmail("");
         buildSpan.setTag(CITags.GIT_COMMIT_COMMITTER_EMAIL, gitCommitterEmail);
 
-        final String gitCommitterDate = buildData.getGitCommitterDate("").isEmpty() ? pipelineData.getGitCommitterDate("") : buildData.getGitCommitterDate("");
+        final String gitCommitterDate = buildData.getGitCommitterDate("").isEmpty() ? updatedBuildData.getGitCommitterDate("") : buildData.getGitCommitterDate("");
         buildSpan.setTag(CITags.GIT_COMMIT_COMMITTER_DATE, gitCommitterDate);
 
-        final String gitDefaultBranch = buildData.getGitDefaultBranch("").isEmpty() ? pipelineData.getGitDefaultBranch("") : buildData.getGitDefaultBranch("");
+        final String gitDefaultBranch = buildData.getGitDefaultBranch("").isEmpty() ? updatedBuildData.getGitDefaultBranch("") : buildData.getGitDefaultBranch("");
         buildSpan.setTag(CITags.GIT_DEFAULT_BRANCH, gitDefaultBranch);
 
-        final String rawGitBranch = buildData.getBranch("").isEmpty() ? pipelineData.getBranch("") : buildData.getBranch("");
+        final String rawGitBranch = buildData.getBranch("").isEmpty() ? updatedBuildData.getBranch("") : buildData.getBranch("");
         final String gitBranch = normalizeBranch(rawGitBranch);
         if(gitBranch != null) {
             buildSpan.setTag(CITags.GIT_BRANCH, gitBranch);
@@ -209,18 +209,29 @@ public class DatadogTraceBuildLogic {
             buildSpan.setTag(CITags.ERROR, true);
         }
 
-        final long propagatedMillisInQueue = Math.max(pipelineData.getPropagatedMillisInQueue(-1L), 0);
+        // If the build is a Jenkins Pipeline, the queue time is included in the root span duration.
+        // We need to adjust the endTime of the root span subtracting the queue time reported by its child span.
+        // The propagated queue time is set DatadogTracePipelineLogic#updateBuildData method.
+        // The queue time reported by DatadogBuildListener#onStarted method is not included in the root span duration.
+        final long propagatedMillisInQueue = Math.max(updatedBuildData.getPropagatedMillisInQueue(-1L), 0);
+
+        // Although the queue time happens before the span startTime, we cannot remove it from the startTime
+        // because there is no API to do it at the end of the trace. Additionally, we cannot create the root span
+        // at the end of the build, because we would lose the logs correlation.
+        // When the root span starts, we don't have the propagated queue time yet. We need to wait till the
+        // end of the pipeline execution and do it in the endTime, adjusting all child spans if needed.
         buildSpan.finish(endTimeMicros - TimeUnit.MILLISECONDS.toMicros(propagatedMillisInQueue));
     }
 
-    private long getMillisInQueue(BuildData buildData, BuildData pipelineData) {
-        if(buildData.getMillisInQueue(-1L) != -1L) {
-            return Math.max(buildData.getMillisInQueue(-1L), 0);
-        } else {
-            final long millisInQueue = pipelineData.getMillisInQueue(-1L);
-            final long propagatedMillisInQueue = pipelineData.getPropagatedMillisInQueue(-1L);
-            return Math.max(Math.max(millisInQueue, propagatedMillisInQueue), 0);
-        }
+    private long getMillisInQueue(BuildData buildData) {
+        // Reported by the Jenkins Queue API.
+        // It's not included in the root span duration.
+        final long millisInQueue = buildData.getMillisInQueue(-1L);
+
+        // Reported by a child span.
+        // It's included in the root span duration.
+        final long propagatedMillisInQueue = buildData.getPropagatedMillisInQueue(-1L);
+        return Math.max(Math.max(millisInQueue, propagatedMillisInQueue), 0);
     }
 
     protected BuildSpanManager getBuildSpanManager() {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
@@ -53,7 +53,6 @@ public class DatadogTraceBuildLogic {
         }
 
         final long startTimeMicros = buildData.getStartTime(0L) * 1000;
-        System.out.println("jenkins.build: start micros:" + startTimeMicros);
 
         final Span buildSpan = tracer.buildSpan("jenkins.build")
                 .withStartTimestamp(startTimeMicros)
@@ -125,7 +124,6 @@ public class DatadogTraceBuildLogic {
         buildSpan.setTag(CITags.WORKSPACE_PATH, workspace);
 
         final String nodeName = buildData.getNodeName("").isEmpty() ? pipelineData.getNodeName("") : buildData.getNodeName("");
-        System.out.println("--- buildData nodeName: " + buildData.getNodeName("") + ", pipelineData: " + pipelineData.getNodeName(""));
 
         buildSpan.setTag(CITags.NODE_NAME, nodeName);
         // If the NodeName == master, we don't set _dd.hostname. It will be overridden by the Datadog Agent. (Traces are only available using Datadog Agent)
@@ -210,8 +208,6 @@ public class DatadogTraceBuildLogic {
         if(Result.FAILURE.toString().equals(jenkinsResult)) {
             buildSpan.setTag(CITags.ERROR, true);
         }
-
-        System.out.println("jenkins.build: end micros:" + endTimeMicros + ", build millisInQueue: "+buildData.getMillisInQueue(-1L)+", pipeline millisInQueue: "+pipelineData.getMillisInQueue(-1L)+", pipeline propagatedMillisInQueue: " + pipelineData.getPropagatedMillisInQueue(-1L));
 
         final long propagatedMillisInQueue = Math.max(pipelineData.getPropagatedMillisInQueue(-1L), 0);
         buildSpan.finish(endTimeMicros - TimeUnit.MILLISECONDS.toMicros(propagatedMillisInQueue));

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
@@ -178,8 +178,6 @@ public class DatadogTracePipelineLogic {
     }
 
     private void sendTrace(final Tracer tracer, final BuildData buildData, final BuildPipelineNode current, final SpanContext parentSpanContext) {
-        System.out.println("-- Node: " + current.getName() + ", Machine: " + current.getNodeName());
-
         if(!isTraceable(current)){
             // If the current node is not traceable, we continue with its children
             for(final BuildPipelineNode child : current.getChildren()) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
@@ -5,11 +5,8 @@ import static org.datadog.jenkins.plugins.datadog.model.BuildPipelineNode.NodeTy
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeBranch;
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeTag;
 
-import datadog.trace.api.DDId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.interceptor.MutableSpan;
-import datadog.trace.core.DDSpan;
-import datadog.trace.core.DDSpanContext;
 import hudson.EnvVars;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -36,10 +33,10 @@ import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
@@ -109,7 +106,7 @@ public class DatadogTracePipelineLogic {
             return;
         }
 
-        buildData.setPropagatedSecondsInQueue(Math.max(pipelineNode.getSecondsInQueue(), pipelineNode.getPropagatedSecondsInQueue()));
+        buildData.setPropagatedMillisInQueue(TimeUnit.NANOSECONDS.toMillis(getNanosInQueue(pipelineNode)));
 
         final String gitBranch = pipelineNode.getEnvVars().get("GIT_BRANCH");
         if(gitBranch != null && buildData.getBranch("").isEmpty()) {
@@ -181,6 +178,8 @@ public class DatadogTracePipelineLogic {
     }
 
     private void sendTrace(final Tracer tracer, final BuildData buildData, final BuildPipelineNode current, final SpanContext parentSpanContext) {
+        System.out.println("-- Node: " + current.getName() + ", Machine: " + current.getNodeName());
+
         if(!isTraceable(current)){
             // If the current node is not traceable, we continue with its children
             for(final BuildPipelineNode child : current.getChildren()) {
@@ -189,8 +188,13 @@ public class DatadogTracePipelineLogic {
             return;
         }
 
+        final long propagatedMillisInQueue = Math.max(buildData.getPropagatedMillisInQueue(-1L), 0);
+        final long fixedStartTimeMicros = current.getStartTimeMicros() - TimeUnit.MILLISECONDS.toMicros(propagatedMillisInQueue);
+        final long fixedEndTimeMicros = current.getEndTimeMicros() - TimeUnit.MILLISECONDS.toMicros(propagatedMillisInQueue);
+
         // At this point, the current node is traceable.
-        final Tracer.SpanBuilder spanBuilder = tracer.buildSpan(buildOperationName(current)).withStartTimestamp(current.getStartTimeMicros());
+        final Tracer.SpanBuilder spanBuilder = tracer.buildSpan(buildOperationName(current))
+                .withStartTimestamp(fixedStartTimeMicros + TimeUnit.NANOSECONDS.toMicros(getNanosInQueue(current)));
         if(parentSpanContext != null) {
             spanBuilder.asChildOf(parentSpanContext);
         }
@@ -238,18 +242,18 @@ public class DatadogTracePipelineLogic {
         //Logs
         //NOTE: Implement sendNodeLogs
 
-        span.finish(current.getEndTimeMicros());
+        span.finish(fixedEndTimeMicros);
+    }
+
+    private Long getNanosInQueue(BuildPipelineNode current) {
+        // If the concrete queue time for this node is not set
+        // we look for the queue time propagated by its children.
+        return Math.max(Math.max(current.getNanosInQueue(), current.getPropagatedNanosInQueue()), 0);
     }
 
     private Map<String, Long> buildTraceMetrics(BuildPipelineNode current) {
         final Map<String, Long> metrics = new HashMap<>();
-        // If the concrete queue time for this node is not set
-        // we look for the queue time propagated by its children.
-        if(current.getSecondsInQueue() == -1L) {
-            metrics.put(CITags.QUEUE_TIME, Math.max(current.getPropagatedSecondsInQueue(), 0));
-        } else {
-            metrics.put(CITags.QUEUE_TIME, Math.max(current.getSecondsInQueue(), 0));
-        }
+        metrics.put(CITags.QUEUE_TIME, TimeUnit.NANOSECONDS.toSeconds(getNanosInQueue(current)));
         return metrics;
     }
 

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListenerIT.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListenerIT.java
@@ -27,6 +27,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class DatadogBuildListenerIT {
 
@@ -75,6 +76,8 @@ public class DatadogBuildListenerIT {
         long queueTime = (long) buildSpan.getUnsafeMetrics().get(CITags.QUEUE_TIME);
         assertTrue(queueTime > 0L);
         assertEquals("none", buildSpan.getTag(CITags._DD_HOSTNAME));
+        assertTrue(queueTime > TimeUnit.NANOSECONDS.toSeconds(buildSpan.getDurationNano()));
+        assertTrue(buildSpan.getDurationNano() > 1L);
     }
 
     @Test

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
@@ -44,6 +44,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class DatadogGraphListenerTest {
 
@@ -306,7 +307,7 @@ public class DatadogGraphListenerTest {
                 throw new RuntimeException(e);
             }
         }).start();
-        Thread.sleep(5000);
+        Thread.sleep(10000);
         jenkinsRule.createOnlineSlave(Label.get("testStage"));
 
 
@@ -329,6 +330,8 @@ public class DatadogGraphListenerTest {
         final DDSpan stage2 = pipelineTrace.get(1);
         long stage2QueueTime = (long) stage2.getUnsafeMetrics().get(CITags.QUEUE_TIME);
         assertTrue(stage2QueueTime > 0L);
+        assertTrue(stage2QueueTime > TimeUnit.NANOSECONDS.toSeconds(stage2.getDurationNano()));
+        assertTrue(stage2.getDurationNano() > 1L);
 
         final DDSpan stepStage2 = pipelineTrace.get(2);
         assertEquals(0L, stepStage2.getUnsafeMetrics().get(CITags.QUEUE_TIME));
@@ -336,6 +339,8 @@ public class DatadogGraphListenerTest {
         final DDSpan stage1 = pipelineTrace.get(3);
         long stage1QueueTime = (long) stage1.getUnsafeMetrics().get(CITags.QUEUE_TIME);
         assertTrue(stage1QueueTime > 0L);
+        assertTrue(stage1QueueTime > TimeUnit.NANOSECONDS.toSeconds(stage1.getDurationNano()));
+        assertTrue(stage1.getDurationNano() > 1L);
 
         final DDSpan stepStage1 = pipelineTrace.get(4);
         assertEquals(0L, stepStage1.getUnsafeMetrics().get(CITags.QUEUE_TIME));
@@ -363,7 +368,7 @@ public class DatadogGraphListenerTest {
                 throw new RuntimeException(e);
             }
         }).start();
-        Thread.sleep(5000);
+        Thread.sleep(15000);
         jenkinsRule.createOnlineSlave(Label.get("testPipeline"));
 
         final ListWriter tracerWriter = clientStub.tracerWriter();
@@ -375,6 +380,9 @@ public class DatadogGraphListenerTest {
         final DDSpan buildSpan = buildTrace.get(0);
         long queueTime = (long) buildSpan.getUnsafeMetrics().get(CITags.QUEUE_TIME);
         assertTrue(queueTime > 0L);
+        assertTrue(queueTime > TimeUnit.NANOSECONDS.toSeconds(buildSpan.getDurationNano()));
+        assertTrue(buildSpan.getDurationNano() > 1L);
+
         assertEquals("testPipeline", buildSpan.getTag(CITags.NODE_NAME));
         assertEquals("none",buildSpan.getTag(CITags._DD_HOSTNAME));
 


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Currently, the queue time is included in the span duration for those cases where the queue time is reported in a Jenkins internal step (for Jenkins Pipelines). 

This happens because the indexed spans don't know the queue time until its `Allocate node : Body : Start` node finishes; this kind of node is a child span from the indexed spans. In these cases, we need to subtract the queue time from the affected spans to obtain a correct span duration.

This PR removes the queue time from the duration of the affected spans.

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

* Subtract the queue time for the `Pipeline` root span (when necessary).
* Adjust the child spans start/end time (if root span was affected).
* Subtract the queue time for `Stage` spans (when necessary).

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

