### PR TITLE
Explicitly removal of all invisible actions when a pipeline finishes.

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -34,7 +34,16 @@ import hudson.model.*;
 import hudson.model.labels.LabelAtom;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.ObjectUtils.Null;
+import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
+import org.datadog.jenkins.plugins.datadog.model.GitCommitAction;
+import org.datadog.jenkins.plugins.datadog.model.GitRepositoryAction;
+import org.datadog.jenkins.plugins.datadog.model.PipelineNodeInfoAction;
+import org.datadog.jenkins.plugins.datadog.model.PipelineQueueInfoAction;
+import org.datadog.jenkins.plugins.datadog.model.StageBreakdownAction;
 import org.datadog.jenkins.plugins.datadog.steps.DatadogPipelineAction;
+import org.datadog.jenkins.plugins.datadog.traces.BuildSpanAction;
+import org.datadog.jenkins.plugins.datadog.traces.IsPipelineAction;
+import org.datadog.jenkins.plugins.datadog.traces.StepDataAction;
 import org.datadog.jenkins.plugins.datadog.util.SuppressFBWarnings;
 import org.datadog.jenkins.plugins.datadog.util.TagsUtil;
 import org.jenkinsci.plugins.pipeline.StageStatus;
@@ -815,6 +824,34 @@ public class DatadogUtilities {
         sb.append("]");
 
         return sb.toString();
+    }
+
+    /**
+     * Removes all actions related to traces for Jenkins pipelines.
+     * @param run the current run.
+     */
+    public static void cleanUpTraceActions(final Run<?, ?> run) {
+        if(run != null) {
+            run.removeActions(BuildSpanAction.class);
+            run.removeActions(StepDataAction.class);
+            run.removeActions(CIGlobalTagsAction.class);
+            run.removeActions(GitCommitAction.class);
+            run.removeActions(GitRepositoryAction.class);
+            run.removeActions(PipelineNodeInfoAction.class);
+            run.removeActions(PipelineQueueInfoAction.class);
+            run.removeActions(StageBreakdownAction.class);
+            run.removeActions(IsPipelineAction.class);
+        }
+    }
+
+    /**
+     * Check if a run is from a Jenkins pipeline.
+     * This action is added if the run is based on FlowNodes.
+     * @param run the current run.
+     * @return true if is a Jenkins pipeline.
+     */
+    public static boolean isPipeline(final Run<?, ?> run) {
+        return run != null && run.getAction(IsPipelineAction.class) != null;
     }
 
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/IsPipelineAction.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/IsPipelineAction.java
@@ -1,0 +1,9 @@
+package org.datadog.jenkins.plugins.datadog.traces;
+
+import hudson.model.InvisibleAction;
+
+import java.io.Serializable;
+
+public class IsPipelineAction extends InvisibleAction implements Serializable {
+    private static final long serialVersionUID = 1L;
+}

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
@@ -886,21 +886,6 @@ public class DatadogGraphListenerTest extends DatadogTraceAbstractTest {
         assertEquals("error", step2Span.getTag(CITags.STATUS));
     }
 
-    @Test
-    public void testCleanUpTracerActions() throws Exception {
-        jenkinsRule.createOnlineSlave(new LabelAtom("windows"));
-        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "pipelineIntegrationCleanUp");
-        String definition = IOUtils.toString(
-                this.getClass().getResourceAsStream("testPipelineDefinition.txt"),
-                "UTF-8"
-        );
-        job.setDefinition(new CpsFlowDefinition(definition, true));
-        final Run<?, ?> run = job.scheduleBuild2(0).get();
-
-        final ListWriter tracerWriter = clientStub.tracerWriter();
-        tracerWriter.waitForTraces(1);
-    }
-
     private void assertNodeNameParallelBlock(DDSpan stageSpan, DumbSlave worker01, DumbSlave worker02) {
         switch ((String)stageSpan.getResourceName()){
             case "Prepare01":

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogTraceAbstractTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogTraceAbstractTest.java
@@ -1,0 +1,47 @@
+package org.datadog.jenkins.plugins.datadog.listeners;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import datadog.trace.core.DDSpan;
+import hudson.model.Run;
+import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
+import org.datadog.jenkins.plugins.datadog.model.GitCommitAction;
+import org.datadog.jenkins.plugins.datadog.model.GitRepositoryAction;
+import org.datadog.jenkins.plugins.datadog.model.PipelineNodeInfoAction;
+import org.datadog.jenkins.plugins.datadog.model.PipelineQueueInfoAction;
+import org.datadog.jenkins.plugins.datadog.model.StageBreakdownAction;
+import org.datadog.jenkins.plugins.datadog.traces.BuildSpanAction;
+import org.datadog.jenkins.plugins.datadog.traces.CITags;
+import org.datadog.jenkins.plugins.datadog.traces.IsPipelineAction;
+import org.datadog.jenkins.plugins.datadog.traces.StepDataAction;
+
+public abstract class DatadogTraceAbstractTest {
+
+    protected void assertGitVariables(DDSpan span, String defaultBranch) {
+        assertEquals("Initial commit\n", span.getTag(CITags.GIT_COMMIT_MESSAGE));
+        assertEquals("John Doe", span.getTag(CITags.GIT_COMMIT_AUTHOR_NAME));
+        assertEquals("john@doe.com", span.getTag(CITags.GIT_COMMIT_AUTHOR_EMAIL));
+        assertEquals("2020-10-08T07:49:32.000Z", span.getTag(CITags.GIT_COMMIT_AUTHOR_DATE));
+        assertEquals("John Doe", span.getTag(CITags.GIT_COMMIT_COMMITTER_NAME));
+        assertEquals("john@doe.com", span.getTag(CITags.GIT_COMMIT_COMMITTER_EMAIL));
+        assertEquals("2020-10-08T07:49:32.000Z", span.getTag(CITags.GIT_COMMIT_COMMITTER_DATE));
+        assertEquals("401d997a6eede777602669ccaec059755c98161f", span.getTag(CITags.GIT_COMMIT__SHA));
+        assertEquals("401d997a6eede777602669ccaec059755c98161f", span.getTag(CITags.GIT_COMMIT_SHA));
+        assertEquals("master", span.getTag(CITags.GIT_BRANCH));
+        assertEquals("https://github.com/johndoe/foobar.git", span.getTag(CITags.GIT_REPOSITORY_URL));
+        assertEquals(defaultBranch, span.getTag(CITags.GIT_DEFAULT_BRANCH));
+    }
+
+    protected void assertCleanupActions(Run<?,?> run) {
+        assertNull(run.getAction(BuildSpanAction.class));
+        assertNull(run.getAction(StepDataAction.class));
+        assertNull(run.getAction(CIGlobalTagsAction.class));
+        assertNull(run.getAction(GitCommitAction.class));
+        assertNull(run.getAction(GitRepositoryAction.class));
+        assertNull(run.getAction(PipelineNodeInfoAction.class));
+        assertNull(run.getAction(PipelineQueueInfoAction.class));
+        assertNull(run.getAction(StageBreakdownAction.class));
+        assertNull(run.getAction(IsPipelineAction.class));
+    }
+}


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

This PR removes explicitly all the `InvisibleAction` instances from the `WorkflowRun` instance used by CI Visibility. This is required to avoid memory leaks due to the action instances are not garbage collected, even if the run has finished.

As the `onFinalized` method is executed before processing the last `FlowNode`, we synchronize the clean-up using the `IsPipelineAction`.

Before the fix -> After executing 20 pipelines

![image](https://user-images.githubusercontent.com/29516565/124493307-c2166a00-ddb5-11eb-8e0c-cf2dbd8a743c.png)

After the fix -> After executing 20 pipelines

![image](https://user-images.githubusercontent.com/29516565/124493340-ce9ac280-ddb5-11eb-817a-51dd328ffa9e.png)

Related to #227 

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

