### PR TITLE
Accept "0" as a valid port value to support UDS

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -78,7 +78,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     //Deprecated
     private static final String BLACKLIST_PROPERTY = "DATADOG_JENKINS_PLUGIN_BLACKLIST";
     private static final String WHITELIST_PROPERTY = "DATADOG_JENKINS_PLUGIN_WHITELIST";
-    
+
     private static final String GLOBAL_TAG_FILE_PROPERTY = "DATADOG_JENKINS_PLUGIN_GLOBAL_TAG_FILE";
     private static final String GLOBAL_TAGS_PROPERTY = "DATADOG_JENKINS_PLUGIN_GLOBAL_TAGS";
     private static final String GLOBAL_JOB_TAGS_PROPERTY = "DATADOG_JENKINS_PLUGIN_GLOBAL_JOB_TAGS";
@@ -181,7 +181,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
         if(StringUtils.isNotBlank(hostnameEnvVar)){
             this.hostname = hostnameEnvVar;
         }
-        
+
         String excludedEnvVar = System.getenv(EXCLUDED_PROPERTY);
         if(StringUtils.isBlank(excludedEnvVar)){
             // backwards compatibility
@@ -192,14 +192,14 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
         } else {
             this.blacklist = excludedEnvVar;
         }
-        
+
         String includedEnvVar = System.getenv(INCLUDED_PROPERTY);
         if(StringUtils.isBlank(includedEnvVar)){
             // backwards compatibility
             includedEnvVar = System.getenv(WHITELIST_PROPERTY);
             if(StringUtils.isNotBlank(includedEnvVar)){
                 this.whitelist = includedEnvVar;
-            }    
+            }
         } else {
             this.whitelist = includedEnvVar;
         }
@@ -552,11 +552,11 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
             if(StringUtils.isNotBlank(this.getHostname()) && !DatadogUtilities.isValidHostname(this.getHostname())){
                 throw new FormException("Your hostname is invalid, likely because it violates the format set in RFC 1123", "hostname");
             }
-            
+
             this.setHostname(formData.getString("hostname"));
             // These config names have to be kept for backwards compatibility reasons
             this.setExcluded(formData.getString("blacklist"));
-            this.setIncluded(formData.getString("whitelist"));          
+            this.setIncluded(formData.getString("whitelist"));
             this.setGlobalTagFile(formData.getString("globalTagFile"));
             this.setGlobalTags(formData.getString("globalTags"));
             this.setGlobalJobTags(formData.getString("globalJobTags"));
@@ -819,7 +819,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     public String getBlacklist() {
         return blacklist;
     }
-    
+
     /**
      * Getter function for the excluded global configuration, containing
      * a comma-separated list of jobs to exclude from monitoring.
@@ -839,7 +839,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     public void setBlacklist(final String jobs) {
         this.blacklist = jobs;
     }
-    
+
     /**
      * Setter function for the excluded jobs global configuration,
      * accepting a comma-separated string of jobs.
@@ -859,7 +859,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     public String getWhitelist() {
         return whitelist;
     }
-    
+
     /**
      * Getter function for the included global configuration, containing
      * a comma-separated list of jobs to include for monitoring.
@@ -879,7 +879,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     public void setWhitelist(final String jobs) {
         this.whitelist = jobs;
     }
-    
+
     /**
      * Setter function for the includedd global configuration,
      * accepting a comma-separated string of jobs.

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -399,7 +399,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     }
 
     public static boolean validatePort(String targetPort) {
-        return StringUtils.isNotBlank(targetPort) && StringUtils.isNumeric(targetPort) && NumberUtils.createInteger(targetPort) != 0;
+        return StringUtils.isNotBlank(targetPort) && StringUtils.isNumeric(targetPort) && NumberUtils.createInteger(targetPort) >= 0;
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

It makes port "0" valid, as the java-dogstatsd-client accepts it to support Unix Domain Socket (UDS).

### Description of the Change

Any string that can be parsed as a positive integer is considered a valid port.

### Alternate Designs

Further improvements could test for `NumberUtils.createInteger(targetPort) <= 65535`, unless there are other special values I am not aware of. Also, the current validation does not test for the hostname to correspond to a socket path when the port is set to 0. 

### Possible Drawbacks

None.

### Verification Process

None.

### Additional Notes

None.

### Release Notes

None.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.