### PR TITLE
Fix ConcurrentModificationException when serializing `StepDataAction`

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogStepListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogStepListener.java
@@ -42,7 +42,9 @@ public class DatadogStepListener implements StepListener {
             }
 
             final StepData stepData = new StepData(context);
-            stepDataAction.put(flowNode, stepData);
+            synchronized (run){
+                stepDataAction.put(flowNode, stepData);
+            }
 
 
             // We use the PipelineNodeInfoAction to propagate

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogStepListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogStepListener.java
@@ -42,9 +42,7 @@ public class DatadogStepListener implements StepListener {
             }
 
             final StepData stepData = new StepData(context);
-            synchronized (run){
-                stepDataAction.put(flowNode, stepData);
-            }
+            stepDataAction.synchronizedPut(run, flowNode, stepData);
 
 
             // We use the PipelineNodeInfoAction to propagate

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
@@ -445,7 +445,7 @@ public class BuildPipelineNode {
             return null;
         }
 
-        return stepDataAction.get(flowNode);
+        return stepDataAction.synchronizedGet(run, flowNode);
     }
 
     private FlowNodeQueueData getQueueData(FlowNode node) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/StepDataAction.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/StepDataAction.java
@@ -12,6 +12,10 @@ import java.util.Map;
 
 /**
  * Keeps the Step data during a certain Run.
+ *
+ * Note: We need to synchronize with the run instance because in parallel pipelines the WorkflowRun.save() method
+ * may raise a ConcurrentModificationException if the action is being persisted and it's modified during the process.
+ * We synchronize based on the run instance because the WorkflowRun.save() method synchronize on this.
  */
 public class StepDataAction extends InvisibleAction implements Serializable {
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/StepDataAction.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/StepDataAction.java
@@ -9,6 +9,8 @@ import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Keeps the Step data during a certain Run.
@@ -21,7 +23,7 @@ public class StepDataAction extends InvisibleAction implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final Map<String, StepData> stepDataByDescriptor = new HashMap<>();
+    private final ConcurrentMap<String, StepData> stepDataByDescriptor = new ConcurrentHashMap<>();
 
     public StepData synchronizedPut(final Run<?,?> run, final FlowNode flowNode, final StepData stepData) {
         synchronized (run){

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/StepDataAction.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/StepDataAction.java
@@ -1,6 +1,7 @@
 package org.datadog.jenkins.plugins.datadog.traces;
 
 import hudson.model.InvisibleAction;
+import hudson.model.Run;
 import org.datadog.jenkins.plugins.datadog.model.StepData;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -18,12 +19,16 @@ public class StepDataAction extends InvisibleAction implements Serializable {
 
     private final Map<String, StepData> stepDataByDescriptor = new HashMap<>();
 
-    public StepData put(final FlowNode flowNode, final StepData stepData) {
-        return stepDataByDescriptor.put(flowNode.getId(), stepData);
+    public StepData synchronizedPut(final Run<?,?> run, final FlowNode flowNode, final StepData stepData) {
+        synchronized (run){
+            return stepDataByDescriptor.put(flowNode.getId(), stepData);
+        }
     }
 
-    public StepData get(final FlowNode flowNode) {
-        return stepDataByDescriptor.get(flowNode.getId());
+    public StepData synchronizedGet(final Run<?,?> run, final FlowNode flowNode) {
+        synchronized (run){
+            return stepDataByDescriptor.get(flowNode.getId());
+        }
     }
 
 }


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

This PR adds a `synchronize` on the `run` instance on modification of the `StepDataAction` internal map.

This fixes the race condition detected in a scenario of parallel pipelines, where the `WorkflowRun.save()` method raises a `ConcurrentModificationException` because the map is modified by other `Thread`.

AIUI `run` here should always be an instance of `WorkflowRun`, [which synchronizes on itself before saving](https://github.com/jenkinsci/workflow-job-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java#L1204), which should prevent the `ConcurrentModificationException`.


```
02:10:38  java.util.ConcurrentModificationException
02:10:38    at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1493)
02:10:38    at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1526)
02:10:38    at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1524)
02:10:38    at com.thoughtworks.xstream.converters.collections.MapConverter.marshal(MapConverter.java:75)
02:10:38    at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
02:10:38    at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
02:10:38    at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
02:10:38    at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:275)
02:10:38    at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:262)
02:10:38  Caused: java.lang.RuntimeException: Failed to serialize org.datadog.jenkins.plugins.datadog.traces.StepDataAction#stepDataByDescriptor for class org.datadog.jenkins.plugins.datadog.traces.StepDataAction
02:10:38    at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:266)
02:10:38    at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:233)
02:10:38    at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:150)
02:10:38    at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:219)
02:10:38    at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:158)
02:10:38    at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
02:10:38    at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
02:10:38    at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:43)
02:10:38    at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:87)
02:10:38    at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.writeBareItem(AbstractCollectionConverter.java:94)
02:10:38    at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.writeItem(AbstractCollectionConverter.java:66)
02:10:38    at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.writeCompleteItem(AbstractCollectionConverter.java:81)
02:10:38    at com.thoughtworks.xstream.converters.collections.CollectionConverter.marshal(CollectionConverter.java:74)
02:10:38    at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
02:10:38    at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
02:10:38    at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
02:10:38    at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:275)
02:10:38    at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:262)
02:10:38  Caused: java.lang.RuntimeException: Failed to serialize hudson.model.Actionable#actions for class org.jenkinsci.plugins.workflow.job.WorkflowRun
02:10:38    at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:266)
02:10:38    at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:233)
02:10:38    at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:150)
02:10:38    at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:219)
02:10:38    at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:158)
02:10:38    at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
02:10:38    at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
02:10:38    at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:43)
02:10:38    at com.thoughtworks.xstream.core.TreeMarshaller.start(TreeMarshaller.java:82)
02:10:38    at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.marshal(AbstractTreeMarshallingStrategy.java:37)
02:10:38    at com.thoughtworks.xstream.XStream.marshal(XStream.java:1278)
02:10:38    at com.thoughtworks.xstream.XStream.marshal(XStream.java:1267)
02:10:38    at com.thoughtworks.xstream.XStream.toXML(XStream.java:1240)
02:10:38    at hudson.util.XStream2.toXMLUTF8(XStream2.java:312)
02:10:38    at org.jenkinsci.plugins.workflow.support.PipelineIOUtils.writeByXStream(PipelineIOUtils.java:34)
02:10:38    at org.jenkinsci.plugins.workflow.job.WorkflowRun.save(WorkflowRun.java:1210)
02:10:38    at hudson.tasks.junit.JUnitResultArchiver.parseAndSummarize(JUnitResultArchiver.java:289)
02:10:38    at hudson.tasks.junit.pipeline.JUnitResultsStepExecution.run(JUnitResultsStepExecution.java:63)
02:10:38    at hudson.tasks.junit.pipeline.JUnitResultsStepExecution.run(JUnitResultsStepExecution.java:29)
02:10:38    at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
02:10:38    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
02:10:38    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
02:10:38    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
02:10:38    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
02:10:38    at java.base/java.lang.Thread.run(Thread.java:834)
```


<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

