### PR TITLE
Properly validate credentials API key before using

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -353,7 +353,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
      */
     public Secret findSecret(String apiKey, String credentialsApiKey) {
         Secret secret = Secret.fromString(apiKey);
-        if (credentialsApiKey != null) {
+        if (credentialsApiKey != null && !StringUtils.isBlank(credentialsApiKey)) {
             StringCredentials credential = this.getCredentialFromId(credentialsApiKey);
             if (credential != null && !credential.getSecret().getPlainText().isEmpty()){
                 secret = credential.getSecret();
@@ -713,12 +713,8 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
             }
             this.setCollectBuildLogs(formData.getBoolean("collectBuildLogs"));
 
-            StringCredentials credential = getCredentialFromId(this.getTargetCredentialsApiKey());
-            if (credential != null) {
-                this.setUsedApiKey(credential.getSecret());
-            } else {
-                this.setUsedApiKey(this.getTargetApiKey());
-            }
+            final Secret apiKeySecret = findSecret(formData.getString("targetApiKey"), formData.getString("targetCredentialsApiKey"));
+            this.setUsedApiKey(apiKeySecret);
             //When form is saved....
             DatadogClient client = ClientFactory.getClient(DatadogClient.ClientType.valueOf(this.getReportWith()),
                     this.getTargetApiURL(), this.getTargetLogIntakeURL(), this.getUsedApiKey(), this.getTargetHost(),


### PR DESCRIPTION
### What does this PR do?

- Address https://github.com/jenkinsci/datadog-plugin/issues/266
- Only use credentials API Key if not blank, and use the same `findSecret` method when validating API key and selecting the API key to use

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

- Install old version of plugin
- Enter API key as a Secret
- Update plugin to new version
- Ensure metrics are still submitting without user intervention

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

