### PR TITLE
Update button text to be more clear

### DIFF
--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -29,13 +29,13 @@
           <f:textbox field="targetLogCollectionPort" default="${targetLogCollectionPort}" checkMethod="post" />
         </f:entry>
 
-        <f:validateButton title="${%Test connection}" progress="${%Testing...}" method="checkAgentConnectivityLogs" with="targetHost,targetLogCollectionPort" />
+        <f:validateButton title="${%Test logs connection}" progress="${%Testing...}" method="checkAgentConnectivityLogs" with="targetHost,targetLogCollectionPort" />
 
         <f:entry title="Traces Collection Port" field="targetTraceCollectionPortEntry" description="(Optional) (Required for CI Visibility)">
             <f:textbox field="targetTraceCollectionPort" default="${targetTraceCollectionPort}" checkMethod="post" />
         </f:entry>
 
-        <f:validateButton title="${%Test connection}" progress="${%Testing...}" method="checkAgentConnectivityTraces" with="targetHost,targetTraceCollectionPort" />
+        <f:validateButton title="${%Test traces connection}" progress="${%Testing...}" method="checkAgentConnectivityTraces" with="targetHost,targetTraceCollectionPort" />
     </f:radioBlock>
 
     <f:radioBlock title="Use Datadog API URL and Key to report to Datadog (not recommended)" name="reportWith" value="HTTP"


### PR DESCRIPTION
### What does this PR do?
This PR makes it more clear that the `Test connection` button only test the `Logs Collection port` and `Traces Collection port`. 
<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change
The `DogStatsD port` is not tested by `Test connection` button since it is a UDP port. This PR makes it more clear what each `Test connection` button does.


### Additional Notes
https://github.com/jenkinsci/datadog-plugin/issues/272
<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

