### PR TITLE
Add option to refresh statsd client when the host's IP has changed

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -102,6 +102,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private static final String EMIT_CONFIG_CHANGE_EVENTS_PROPERTY = "DATADOG_JENKINS_PLUGIN_EMIT_CONFIG_CHANGE_EVENTS";
     private static final String COLLECT_BUILD_LOGS_PROPERTY = "DATADOG_JENKINS_PLUGIN_COLLECT_BUILD_LOGS";
     private static final String RETRY_LOGS_PROPERTY = "DATADOG_JENKINS_PLUGIN_RETRY_LOGS";
+    private static final String REFRESH_DOGSTATSD_CLIENT_PROPERTY = "DATADOG_REFRESH_STATSD_CLIENT";
 
     private static final String ENABLE_CI_VISIBILITY_PROPERTY = "DATADOG_JENKINS_PLUGIN_ENABLE_CI_VISIBILITY";
     private static final String CI_VISIBILITY_CI_INSTANCE_NAME_PROPERTY = "DATADOG_JENKINS_PLUGIN_CI_VISIBILITY_CI_INSTANCE_NAME";
@@ -120,6 +121,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private static final boolean DEFAULT_COLLECT_BUILD_LOGS_VALUE = false;
     private static final boolean DEFAULT_COLLECT_BUILD_TRACES_VALUE = false;
     private static final boolean DEFAULT_RETRY_LOGS_VALUE = true;
+    private static final boolean DEFAULT_REFRESH_DOGSTATSD_CLIENT_VALUE = false;
 
     private String reportWith = DEFAULT_REPORT_WITH_VALUE;
     private String targetApiURL = DEFAULT_TARGET_API_URL_VALUE;
@@ -144,6 +146,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private boolean collectBuildLogs = DEFAULT_COLLECT_BUILD_LOGS_VALUE;
     private boolean collectBuildTraces = DEFAULT_COLLECT_BUILD_TRACES_VALUE;
     private boolean retryLogs = DEFAULT_RETRY_LOGS_VALUE;
+    private boolean refreshDogstatsdClient = DEFAULT_REFRESH_DOGSTATSD_CLIENT_VALUE;
 
     @DataBoundConstructor
     public DatadogGlobalConfiguration() {
@@ -262,6 +265,11 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
         String retryLogsEnvVar = System.getenv(RETRY_LOGS_PROPERTY);
         if(StringUtils.isNotBlank(retryLogsEnvVar)){
             this.retryLogs = Boolean.valueOf(retryLogsEnvVar);
+        }
+
+        String refreshDogstatsdClientEnvVar = System.getenv(REFRESH_DOGSTATSD_CLIENT_PROPERTY);
+        if(StringUtils.isNotBlank(refreshDogstatsdClientEnvVar)){
+            this.refreshDogstatsdClient = Boolean.valueOf(refreshDogstatsdClientEnvVar);
         }
 
         String enableCiVisibilityVar = System.getenv(ENABLE_CI_VISIBILITY_PROPERTY);
@@ -704,6 +712,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
             this.setGlobalJobTags(formData.getString("globalJobTags"));
             this.setEmitSecurityEvents(formData.getBoolean("emitSecurityEvents"));
             this.setRetryLogs(formData.getBoolean("retryLogs"));
+            this.setRefreshDogstatsdClient(formData.getBoolean("refreshDogstatsdClient"));
             this.setEmitSystemEvents(formData.getBoolean("emitSystemEvents"));
             this.setEmitConfigChangeEvents(formData.getBoolean("emitConfigChangeEvents"));
 
@@ -1169,6 +1178,23 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     @DataBoundSetter
     public void setRetryLogs(boolean retryLogs) {
         this.retryLogs = retryLogs;
+    }
+
+    /**
+     * @return - A {@link Boolean} indicating if the user has configured Datadog to refresh the dogstatsd client
+     */
+    public boolean isRefreshDogstatsdClient() {
+        return refreshDogstatsdClient;
+    }
+
+    /**
+     * Set the checkbox in the UI, used for Jenkins data binding
+     *
+     * @param refreshDogstatsdClient - The checkbox status (checked/unchecked)
+     */
+    @DataBoundSetter
+    public void setRefreshDogstatsdClient(boolean refreshDogstatsdClient) {
+        this.refreshDogstatsdClient = refreshDogstatsdClient;
     }
 
     /**

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
@@ -52,6 +52,7 @@ import org.datadog.jenkins.plugins.datadog.util.TagsUtil;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 import java.net.ConnectException;
+import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URL;
 import java.net.UnknownHostException;
@@ -86,6 +87,7 @@ public class DatadogAgentClient implements DatadogClient {
     private String previousPayload;
 
     private String hostname = null;
+    private String resolvedIp = "";
     private Integer port = null;
     private Integer logCollectionPort = null;
     private Integer traceCollectionPort = null;
@@ -206,7 +208,8 @@ public class DatadogAgentClient implements DatadogClient {
      */
     private boolean reinitializeStatsDClient(boolean force) {
         try {
-            if(!this.isStoppedStatsDClient && this.statsd != null && !force){
+            boolean refreshClient = DatadogUtilities.getDatadogGlobalDescriptor().isRefreshDogstatsdClient();
+            if(!this.isStoppedStatsDClient && this.statsd != null && !force && (!refreshClient || !this.hasIpChanged())){
                 return true;
             }
             this.stopStatsDClient();
@@ -214,11 +217,27 @@ public class DatadogAgentClient implements DatadogClient {
             this.statsd = new NonBlockingStatsDClient(null, this.hostname, this.port);
             this.isStoppedStatsDClient = false;
         } catch (Exception e){
-            DatadogUtilities.severe(logger, e, "Failed to reinitialize DogStatsD Client");
+            DatadogUtilities.severe(logger, e, null);
             this.stopStatsDClient();
         }
 
         return !isStoppedStatsDClient;
+    }
+
+    private String resolveHostnameIp() throws UnknownHostException {
+        InetAddress inet = InetAddress.getByName(this.hostname);
+        String ipAddress = inet.getHostAddress();
+        return ipAddress;
+    }
+
+    private boolean hasIpChanged() throws UnknownHostException {
+        String ipAddress = this.resolveHostnameIp();
+        if (this.resolvedIp.equals(ipAddress)) {
+            return false;
+        } else {
+            this.resolvedIp = ipAddress;
+            return true;
+        }
     }
 
     /**

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
@@ -217,7 +217,7 @@ public class DatadogAgentClient implements DatadogClient {
             this.statsd = new NonBlockingStatsDClient(null, this.hostname, this.port);
             this.isStoppedStatsDClient = false;
         } catch (Exception e){
-            DatadogUtilities.severe(logger, e, null);
+            DatadogUtilities.severe(logger, e, "Failed to reinitialize DogStatsD Client");
             this.stopStatsDClient();
         }
 

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -114,6 +114,11 @@
             <f:checkbox title="Retry Logs" field="retryLogs" default="true" />
         </f:entry>
 
+
+        <f:entry title="Refresh Dogstatsd Client" description="Refresh Dogstatsd Client when your agent IP changes">
+            <f:checkbox title="Refresh Dogstatsd Client" field="refreshDogstatsdClient" default="false" />
+        </f:entry>
+
         <f:entry title="System Events">
           <f:entry description="Send system events like Node changes of states.">
             <f:checkbox title="Send System events" field="emitSystemEvents" default="true" />


### PR DESCRIPTION
### What does this PR do?

Adds an option to refresh the statsd client when the hostname's IP changed

### Description of the Change
When the option is enabled, the agent client will first check if the IP has changed since the last metric submission, if it has, then it will update the IP and re-initialize the statsd client

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

