### PR TITLE
Fix ConcurrentModificationException when serializing `PipelineQueueInfoAction`

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogQueueListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogQueueListener.java
@@ -59,13 +59,13 @@ public class DatadogQueueListener extends QueueListener {
                 return;
             }
 
-            final FlowNodeQueueData flowNodeData = queueAction.get(flowNode.getId());
+            final FlowNodeQueueData flowNodeData = queueAction.synchronizedGet(run, flowNode.getId());
             if(flowNodeData != null) {
                 flowNodeData.setEnterBuildableNanos(System.nanoTime());
             } else {
                 final FlowNodeQueueData data = new FlowNodeQueueData(flowNode.getId());
                 data.setEnterBuildableNanos(System.nanoTime());
-                queueAction.put(flowNode.getId(), data);
+                queueAction.synchronizedPut(run, flowNode.getId(), data);
             }
 
         } catch (Exception e){
@@ -108,7 +108,7 @@ public class DatadogQueueListener extends QueueListener {
                 return;
             }
 
-            final FlowNodeQueueData flowNodeData = queueAction.get(flowNode.getId());
+            final FlowNodeQueueData flowNodeData = queueAction.synchronizedGet(run, flowNode.getId());
             if(flowNodeData != null) {
                 flowNodeData.setLeaveBuildableNanos(System.nanoTime());
             }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
@@ -484,7 +484,7 @@ public class BuildPipelineNode {
             return null;
         }
 
-        return pipelineQueueInfoAction.get(node.getId());
+        return pipelineQueueInfoAction.synchronizedGet(run, node.getId());
     }
 
     private Run<?, ?> getRun(final FlowNode node) {


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

This PR adds a synchronize on the run instance on modification of the `PipelineQueueInfoAction` internal map.
Similar fix was applied in this PR: https://github.com/jenkinsci/datadog-plugin/pull/243

This fixes the race condition detected in a scenario of parallel pipelines, where the `WorkflowRun.save()` method raises a `ConcurrentModificationException` because the map is modified by other Thread.

AIUI `run` here should always be an instance of `WorkflowRun`, [which synchronizes on itself before saving](https://github.com/jenkinsci/workflow-job-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java#L1204), which should prevent the `ConcurrentModificationException`.

```
java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1445)
	at java.util.HashMap$EntryIterator.next(HashMap.java:1479)
	at java.util.HashMap$EntryIterator.next(HashMap.java:1477)
	at com.thoughtworks.xstream.converters.collections.MapConverter.marshal(MapConverter.java:75)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
	at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:278)
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:265)
Caused: java.lang.RuntimeException: Failed to serialize org.datadog.jenkins.plugins.datadog.model.PipelineQueueInfoAction#queueDataByFlowNode for class org.datadog.jenkins.plugins.datadog.model.PipelineQueueInfoAction
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:269)
	at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:236)
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:174)
	at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:221)
	at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:160)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:43)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:87)
	at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.writeBareItem(AbstractCollectionConverter.java:94)
	at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.writeItem(AbstractCollectionConverter.java:66)
	at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.writeCompleteItem(AbstractCollectionConverter.java:81)
	at com.thoughtworks.xstream.converters.collections.CollectionConverter.marshal(CollectionConverter.java:74)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
	at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:278)
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:265)
Caused: java.lang.RuntimeException: Failed to serialize hudson.model.Actionable#actions for class org.jenkinsci.plugins.workflow.job.WorkflowRun
	at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:269)
	at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:236)
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:174)
	at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:221)
	at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:160)
	at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
	at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:43)
	at com.thoughtworks.xstream.core.TreeMarshaller.start(TreeMarshaller.java:82)
	at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.marshal(AbstractTreeMarshallingStrategy.java:37)
	at com.thoughtworks.xstream.XStream.marshal(XStream.java:1243)
	at com.thoughtworks.xstream.XStream.marshal(XStream.java:1232)
	at com.thoughtworks.xstream.XStream.toXML(XStream.java:1205)
	at hudson.util.XStream2.toXMLUTF8(XStream2.java:325)
	at org.jenkinsci.plugins.workflow.support.PipelineIOUtils.writeByXStream(PipelineIOUtils.java:34)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.save(WorkflowRun.java:1218)
	at hudson.BulkChange.commit(BulkChange.java:97)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1485)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup$3.run(CpsThreadGroup.java:491)
	at org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService$1.run(CpsVmExecutorService.java:38)
	at hudson.remoting.SingleLaneExecutorService$1.run(SingleLaneExecutorService.java:139)
	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

