### PR TITLE
Tag logs with timestamp, datadog.product and ci.pipeline.name

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
@@ -37,6 +37,8 @@ import org.datadog.jenkins.plugins.datadog.util.TagsUtil;
 
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 public class DatadogWriter {
@@ -65,7 +67,9 @@ public class DatadogWriter {
 
             JSONObject payload = buildData.addLogAttributes();
 
-            payload.put("ddtags", String.join(",", TagsUtil.convertTagsToArray(this.buildData.getTags())));
+            Map<String, Set<String>> ddtags = this.buildData.getTags();
+            TagsUtil.addTagToTags(ddtags, "datadog.product", "cipipeline");
+            payload.put("ddtags", String.join(",", TagsUtil.convertTagsToArray(ddtags)));
             payload.put("message", line);
             payload.put("ddsource", "jenkins");
             payload.put("service", "jenkins");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
@@ -67,6 +67,7 @@ public class DatadogWriter {
             payload.put("message", line);
             payload.put("ddsource", "jenkins");
             payload.put("service", "jenkins");
+            payload.put("timestamp", System.currentTimeMillis());
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
@@ -31,6 +31,8 @@ import org.datadog.jenkins.plugins.datadog.DatadogClient;
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
 import org.datadog.jenkins.plugins.datadog.clients.ClientFactory;
 import org.datadog.jenkins.plugins.datadog.model.BuildData;
+import org.datadog.jenkins.plugins.datadog.model.BuildPipelineNode;
+import org.datadog.jenkins.plugins.datadog.traces.CITags;
 import org.datadog.jenkins.plugins.datadog.util.TagsUtil;
 
 import java.io.OutputStream;
@@ -68,6 +70,7 @@ public class DatadogWriter {
             payload.put("ddsource", "jenkins");
             payload.put("service", "jenkins");
             payload.put("timestamp", System.currentTimeMillis());
+            payload.put(BuildPipelineNode.NodeType.PIPELINE.getTagName() + CITags._NAME, this.buildData.getBaseJobName(""));
 
             // Get Datadog Client Instance
             DatadogClient client = ClientFactory.getClient();

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -416,6 +416,7 @@ public class BuildData implements Serializable {
         }
         allTags = TagsUtil.merge(allTags, tags);
         allTags = TagsUtil.addTagToTags(allTags, "job", getJobName("unknown"));
+        allTags = TagsUtil.addTagToTags(allTags, "datadog.product", "cipipeline");
 
         if (nodeName != null) {
             allTags = TagsUtil.addTagToTags(allTags, "node", getNodeName("unknown"));

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -205,14 +205,14 @@ public class BuildData implements Serializable {
         } catch(NullPointerException e){
             //noop
         }
-        setBaseJobName(baseJobName == null ? null : baseJobName.replaceAll("»", "/").replaceAll(" ", ""));
+        setBaseJobName(normalizeJobName(baseJobName));
         String jobNameWithConfiguration = null;
         try {
             jobNameWithConfiguration = run.getParent().getFullName();
         } catch(NullPointerException e){
             //noop
         }
-        setJobName(jobNameWithConfiguration == null ? null : jobNameWithConfiguration.replaceAll("»", "/").replaceAll(" ", ""));
+        setJobName(normalizeJobName(jobNameWithConfiguration));
 
         // Set Jenkins Url
         String jenkinsUrl = DatadogUtilities.getJenkinsUrl();
@@ -979,6 +979,13 @@ public class BuildData implements Serializable {
             DatadogUtilities.severe(LOGGER, e, "Failed to construct log attributes");
             return new JSONObject();
         }
+    }
+
+    private static String normalizeJobName(String jobName) {
+        if (jobName == null) {
+            return null;
+        }
+        return jobName.replaceAll("»", "/").replaceAll(" ", "");
     }
 
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -88,6 +88,7 @@ public class BuildData implements Serializable {
     private String charsetName;
     private String nodeName;
     private String jobName;
+    private String baseJobName;
     private String buildTag;
     private String jenkinsUrl;
     private String executorNumber;
@@ -195,13 +196,24 @@ public class BuildData implements Serializable {
         setCharset(run.getCharset());
 
         // Set Job Name
-        String jobName = null;
+        String baseJobName = null;
         try {
-            jobName = run.getParent().getFullName();
+            baseJobName = run.getParent().getParent().getFullName();
+            if (baseJobName.length() == 0) {
+                baseJobName = run.getParent().getName();
+            }
         } catch(NullPointerException e){
             //noop
         }
-        setJobName(jobName == null ? null : jobName.replaceAll("»", "/").replaceAll(" ", ""));
+        setBaseJobName(baseJobName == null ? null : baseJobName.replaceAll("»", "/").replaceAll(" ", ""));
+        String jobNameWithConfiguration = null;
+        try {
+            jobNameWithConfiguration = run.getParent().getFullName();
+        } catch(NullPointerException e){
+            //noop
+        }
+        setJobName(jobNameWithConfiguration == null ? null : jobNameWithConfiguration.replaceAll("»", "/").replaceAll(" ", ""));
+
         // Set Jenkins Url
         String jenkinsUrl = DatadogUtilities.getJenkinsUrl();
         if("unknown".equals(jenkinsUrl) && envVars != null && envVars.get("JENKINS_URL") != null
@@ -466,6 +478,14 @@ public class BuildData implements Serializable {
 
     public void setJobName(String jobName) {
         this.jobName = jobName;
+    }
+
+    public String getBaseJobName(String value) {
+        return defaultIfNull(baseJobName, value);
+    }
+
+    public void setBaseJobName(String baseJobName) {
+        this.baseJobName = baseJobName;
     }
 
     public String getResult(String value) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -428,7 +428,6 @@ public class BuildData implements Serializable {
         }
         allTags = TagsUtil.merge(allTags, tags);
         allTags = TagsUtil.addTagToTags(allTags, "job", getJobName("unknown"));
-        allTags = TagsUtil.addTagToTags(allTags, "datadog.product", "cipipeline");
 
         if (nodeName != null) {
             allTags = TagsUtil.addTagToTags(allTags, "node", getNodeName("unknown"));

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
@@ -225,9 +225,11 @@ public class DatadogTraceBuildLogic {
         buildSpan.setResourceName(buildData.getBaseJobName(""));
         buildSpan.putMeta(prefix + CITags._NAME, buildData.getBaseJobName(""));
 
-        final JobNameWrapper jobNameWrapper = new JobNameWrapper(buildData.getJobName(""), gitBranch != null ? gitBranch : gitTag);
-        if(!jobNameWrapper.getConfigurations().isEmpty()){
-            for(Map.Entry<String, String> entry : jobNameWrapper.getConfigurations().entrySet()) {
+        final String fullJobName = buildData.getJobName("");
+        final String gitRef = gitBranch != null ? gitBranch : gitTag;
+        final Map<String, String> configurations = JobNameConfigurationParser.getConfigurations(fullJobName, gitRef);
+        if(!configurations.isEmpty()){
+            for(Map.Entry<String, String> entry : configurations.entrySet()) {
                 buildSpan.putMeta(prefix + CITags._CONFIGURATION + "." + entry.getKey(), entry.getValue());
             }
         }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
@@ -222,15 +222,13 @@ public class DatadogTraceBuildLogic {
             buildSpan.putMeta(CITags.GIT_TAG, gitTag);
         }
 
+        buildSpan.setResourceName(buildData.getBaseJobName(""));
+        buildSpan.putMeta(prefix + CITags._NAME, buildData.getBaseJobName(""));
+
         final JobNameWrapper jobNameWrapper = new JobNameWrapper(buildData.getJobName(""), gitBranch != null ? gitBranch : gitTag);
-        buildSpan.setResourceName(jobNameWrapper.getTraceJobName());
-
-        buildSpan.putMeta(prefix + CITags._NAME, jobNameWrapper.getTraceJobName());
-
         if(!jobNameWrapper.getConfigurations().isEmpty()){
             for(Map.Entry<String, String> entry : jobNameWrapper.getConfigurations().entrySet()) {
                 buildSpan.putMeta(prefix + CITags._CONFIGURATION + "." + entry.getKey(), entry.getValue());
-
             }
         }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
@@ -456,8 +456,7 @@ public class DatadogTracePipelineLogic {
         }
 
         // Propagate Pipeline Name
-        final JobNameWrapper jobNameWrapper = new JobNameWrapper(buildData.getJobName(""), gitBranch != null ? gitBranch : gitTag);
-        tags.put(PIPELINE.getTagName() + CITags._NAME, jobNameWrapper.getTraceJobName());
+        tags.put(PIPELINE.getTagName() + CITags._NAME, buildData.getBaseJobName(""));
         tags.put(PIPELINE.getTagName() + CITags._ID, buildData.getBuildTag(""));
 
         // Propagate Stage Name

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/JobNameConfigurationParser.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/JobNameConfigurationParser.java
@@ -3,11 +3,12 @@ package org.datadog.jenkins.plugins.datadog.traces;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Wrapper for the JobName to extract the configurations for traces.
+ * Extract the configurations from the full JobName for traces.
  *
  * Example1: (Freestyle Project)
  * - Jenkins job name: jobName
@@ -18,17 +19,17 @@ import java.util.Map;
  * -- Configurations: EMPTY
  *
  * Example3: (Multiconfigurations project)
- * - Jenkins job name: jobName/KEY1=VALUE1,KEY2=VALUE2/master
+ * - Jenkins job name: jobName/KEY1=VALUE1,KEY2=VALUE2
  * -- Configurations: map(key1=valu2, key2=value2)
  */
-public class JobNameWrapper {
+public class JobNameConfigurationParser {
 
-    private final Map<String, String> configurations = new HashMap<>();
-
-    public JobNameWrapper(final String jobName, final String gitBranch) {
+    public static Map<String, String> getConfigurations(final String jobName, final String gitBranch) {
         if(jobName == null) {
-            return;
+            return Collections.EMPTY_MAP;
         }
+
+        final Map<String, String> ret = new HashMap<>();
 
         final String rawJobName = jobName.trim();
         String jobNameNoBranch = rawJobName;
@@ -57,12 +58,11 @@ public class JobNameWrapper {
             final String[] configsKeyValue = configsStr.split(",");
             for(final String configKeyValue : configsKeyValue) {
                 final String[] keyValue = configKeyValue.trim().split("=");
-                configurations.put(keyValue[0], keyValue[1]);
+                ret.put(keyValue[0], keyValue[1]);
             }
         }
+
+        return ret;
     }
 
-    public Map<String, String> getConfigurations() {
-        return configurations;
-    }
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/JobNameWrapper.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/JobNameWrapper.java
@@ -7,31 +7,26 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Wrapper for the JobName to extract the job name and configurations for traces.
+ * Wrapper for the JobName to extract the configurations for traces.
  *
  * Example1: (Freestyle Project)
  * - Jenkins job name: jobName
- * -- TraceJobName: jobName
  * -- Configurations: EMPTY
  *
  * Example2: (Multibranch Pipeline)
  * - Jenkins job name: jobName/master
- * -- TraceJobName: jobName
  * -- Configurations: EMPTY
  *
  * Example3: (Multiconfigurations project)
  * - Jenkins job name: jobName/KEY1=VALUE1,KEY2=VALUE2/master
- * -- TraceJobName: jobName
  * -- Configurations: map(key1=valu2, key2=value2)
  */
 public class JobNameWrapper {
 
-    private final String traceJobName;
     private final Map<String, String> configurations = new HashMap<>();
 
     public JobNameWrapper(final String jobName, final String gitBranch) {
         if(jobName == null) {
-            this.traceJobName = null;
             return;
         }
 
@@ -65,20 +60,6 @@ public class JobNameWrapper {
                 configurations.put(keyValue[0], keyValue[1]);
             }
         }
-
-        if(configurations.isEmpty()) {
-            //If there is no configurations,
-            //the jobName is the original one without branch.
-            this.traceJobName = jobNameNoBranch;
-        } else {
-            //If there are configurations,
-            //the jobName is the first part of the splited raw jobName.
-            this.traceJobName = jobNameParts[0];
-        }
-    }
-
-    public String getTraceJobName() {
-        return traceJobName;
     }
 
     public Map<String, String> getConfigurations() {

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/traces/JobNameConfigurationParserTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/traces/JobNameConfigurationParserTest.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RunWith(Parameterized.class)
-public class JobNameWrapperTest {
+public class JobNameConfigurationParserTest {
 
     private static final Map<String, String> EMPTY_MAP = Collections.EMPTY_MAP;
 
@@ -47,7 +47,7 @@ public class JobNameWrapperTest {
     private final String gitBranch;
     private final Map<String, String> expectedConfigs;
 
-    public JobNameWrapperTest(final String rawJobName, final String gitBranch, final Map<String, String> expectedConfigs) {
+    public JobNameConfigurationParserTest(final String rawJobName, final String gitBranch, final Map<String, String> expectedConfigs) {
         this.rawJobName = rawJobName;
         this.gitBranch = gitBranch;
         this.expectedConfigs = expectedConfigs;
@@ -55,8 +55,7 @@ public class JobNameWrapperTest {
 
     @Test
     public void shouldReturnCorrectJobName() {
-        final JobNameWrapper sut = new JobNameWrapper(this.rawJobName, this.gitBranch);
-        assertEquals(this.expectedConfigs, sut.getConfigurations());
+        assertEquals(this.expectedConfigs, JobNameConfigurationParser.getConfigurations(this.rawJobName, this.gitBranch));
     }
 
 }

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/traces/JobNameWrapperTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/traces/JobNameWrapperTest.java
@@ -24,19 +24,19 @@ public class JobNameWrapperTest {
         sampleMap.put("key2", "value2");
 
         final Object[][] data = new Object[][] {
-                {null, null, null, EMPTY_MAP},
-                {null, "master", null, EMPTY_MAP},
-                {"", "master", "", EMPTY_MAP},
-                {"jobName", null, "jobName", EMPTY_MAP},
-                {"jobName", "", "jobName", EMPTY_MAP},
-                {"jobName", "master", "jobName", EMPTY_MAP},
-                {"jobName/master", "master", "jobName", EMPTY_MAP},
-                {"jobName/another", "master", "jobName/another", EMPTY_MAP},
-                {"jobName/another/branch", "another/branch", "jobName", EMPTY_MAP},
-                {"jobName/another%2Fbranch", "another/branch", "jobName", EMPTY_MAP},
-                {"jobName/KEY1=VALUE1,KEY2=VALUE2", "master", "jobName", sampleMap},
-                {"jobName/KEY1=VALUE1,KEY2=VALUE2/master", "master", "jobName", sampleMap},
-                {"jobName/KEY1=VALUE1,KEY2=VALUE2/another-branch", "master", "jobName", sampleMap}
+                {null, null, EMPTY_MAP},
+                {null, "master", EMPTY_MAP},
+                {"", "master", EMPTY_MAP},
+                {"jobName", null, EMPTY_MAP},
+                {"jobName", "", EMPTY_MAP},
+                {"jobName", "master", EMPTY_MAP},
+                {"jobName/master", "master", EMPTY_MAP},
+                {"jobName/another", "master", EMPTY_MAP},
+                {"jobName/another/branch", "another/branch", EMPTY_MAP},
+                {"jobName/another%2Fbranch", "another/branch", EMPTY_MAP},
+                {"jobName/KEY1=VALUE1,KEY2=VALUE2", "master", sampleMap},
+                {"jobName/KEY1=VALUE1,KEY2=VALUE2/master", "master", sampleMap},
+                {"jobName/KEY1=VALUE1,KEY2=VALUE2/another-branch", "master", sampleMap}
         };
 
 
@@ -45,20 +45,17 @@ public class JobNameWrapperTest {
 
     private final String rawJobName;
     private final String gitBranch;
-    private final String expectedJobName;
     private final Map<String, String> expectedConfigs;
 
-    public JobNameWrapperTest(final String rawJobName, final String gitBranch, final String expectedJobName, final Map<String, String> expectedConfigs) {
+    public JobNameWrapperTest(final String rawJobName, final String gitBranch, final Map<String, String> expectedConfigs) {
         this.rawJobName = rawJobName;
         this.gitBranch = gitBranch;
-        this.expectedJobName = expectedJobName;
         this.expectedConfigs = expectedConfigs;
     }
 
     @Test
     public void shouldReturnCorrectJobName() {
         final JobNameWrapper sut = new JobNameWrapper(this.rawJobName, this.gitBranch);
-        assertEquals(this.expectedJobName, sut.getTraceJobName());
         assertEquals(this.expectedConfigs, sut.getConfigurations());
     }
 


### PR DESCRIPTION
### What does this PR do?

Adds the `timestamp`, `datadog.product` and `ci.pipeline.name` tags to logs, matching logs produced by other CIs.

I changed the way we read the pipeline name so it doesn't require git information, since that's not available when we create the logs `DatadogWriter` object.

### Verification Process

After sending logs with this patch, the new fields should show up here:

![Screenshot_20220721_122232](https://user-images.githubusercontent.com/980842/180191819-f66bf6c6-a8e1-470c-9a5e-d6291d24bead.png)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

