### PR TITLE
Remove unneeded log4j exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,29 +181,6 @@
           </archive>
         </configuration>
       </plugin>
-      <!-- CVE-2021-44228- we can remove once parent pom is updated to 4.32 -->
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>display-info</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>display-info</goal>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <bannedDependencies>
-                  <excludes>
-                    <exclude>org.apache.logging.log4j:*:(,2.17.0]</exclude>
-                  </excludes>
-                </bannedDependencies>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
### What does this PR do?

Removes the log4j exclusion rule from the pom since it is no longer needed, as https://github.com/jenkinsci/datadog-plugin/pull/296 bumped the parent pom > 4.32 which includes this exclusion by default, see https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.32

### Description of the Change

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

