### PR TITLE
Add option to not cache build run when calculating pause duration

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -1209,7 +1209,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     /**
      * @return - A {@link Boolean} indicating if the user has configured Datadog to cache build runs
      */
-    public boolean doCacheBuildRuns() {
+    public boolean isCacheBuildRuns() {
         return cacheBuildRuns;
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -103,6 +103,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private static final String COLLECT_BUILD_LOGS_PROPERTY = "DATADOG_JENKINS_PLUGIN_COLLECT_BUILD_LOGS";
     private static final String RETRY_LOGS_PROPERTY = "DATADOG_JENKINS_PLUGIN_RETRY_LOGS";
     private static final String REFRESH_DOGSTATSD_CLIENT_PROPERTY = "DATADOG_REFRESH_STATSD_CLIENT";
+    private static final String CACHE_BUILD_RUNS_PROPERTY = "DATADOG_CACHE_BUILD_RUNS";
 
     private static final String ENABLE_CI_VISIBILITY_PROPERTY = "DATADOG_JENKINS_PLUGIN_ENABLE_CI_VISIBILITY";
     private static final String CI_VISIBILITY_CI_INSTANCE_NAME_PROPERTY = "DATADOG_JENKINS_PLUGIN_CI_VISIBILITY_CI_INSTANCE_NAME";
@@ -122,6 +123,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private static final boolean DEFAULT_COLLECT_BUILD_TRACES_VALUE = false;
     private static final boolean DEFAULT_RETRY_LOGS_VALUE = true;
     private static final boolean DEFAULT_REFRESH_DOGSTATSD_CLIENT_VALUE = false;
+    private static final boolean DEFAULT_CACHE_BUILD_RUNS_VALUE = true;
 
     private String reportWith = DEFAULT_REPORT_WITH_VALUE;
     private String targetApiURL = DEFAULT_TARGET_API_URL_VALUE;
@@ -147,6 +149,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private boolean collectBuildTraces = DEFAULT_COLLECT_BUILD_TRACES_VALUE;
     private boolean retryLogs = DEFAULT_RETRY_LOGS_VALUE;
     private boolean refreshDogstatsdClient = DEFAULT_REFRESH_DOGSTATSD_CLIENT_VALUE;
+    private boolean cacheBuildRuns = DEFAULT_CACHE_BUILD_RUNS_VALUE;
 
     @DataBoundConstructor
     public DatadogGlobalConfiguration() {
@@ -270,6 +273,11 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
         String refreshDogstatsdClientEnvVar = System.getenv(REFRESH_DOGSTATSD_CLIENT_PROPERTY);
         if(StringUtils.isNotBlank(refreshDogstatsdClientEnvVar)){
             this.refreshDogstatsdClient = Boolean.valueOf(refreshDogstatsdClientEnvVar);
+        }
+
+        String cacheBuildRunsEnvVar = System.getenv(CACHE_BUILD_RUNS_PROPERTY);
+        if(StringUtils.isNotBlank(cacheBuildRunsEnvVar)){
+            this.cacheBuildRuns = Boolean.valueOf(cacheBuildRunsEnvVar);
         }
 
         String enableCiVisibilityVar = System.getenv(ENABLE_CI_VISIBILITY_PROPERTY);
@@ -713,6 +721,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
             this.setEmitSecurityEvents(formData.getBoolean("emitSecurityEvents"));
             this.setRetryLogs(formData.getBoolean("retryLogs"));
             this.setRefreshDogstatsdClient(formData.getBoolean("refreshDogstatsdClient"));
+            this.setCacheBuildRuns(formData.getBoolean("cacheBuildRuns"));
             this.setEmitSystemEvents(formData.getBoolean("emitSystemEvents"));
             this.setEmitConfigChangeEvents(formData.getBoolean("emitConfigChangeEvents"));
 
@@ -1195,6 +1204,23 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     @DataBoundSetter
     public void setRefreshDogstatsdClient(boolean refreshDogstatsdClient) {
         this.refreshDogstatsdClient = refreshDogstatsdClient;
+    }
+
+    /**
+     * @return - A {@link Boolean} indicating if the user has configured Datadog to cache build runs
+     */
+    public boolean doCacheBuildRuns() {
+        return cacheBuildRuns;
+    }
+
+    /**
+     * Set the checkbox in the UI, used for Jenkins data binding
+     *
+     * @param cacheBuildRuns - The checkbox status (checked/unchecked)
+     */
+    @DataBoundSetter
+    public void setCacheBuildRuns(boolean cacheBuildRuns) {
+        this.cacheBuildRuns = cacheBuildRuns;
     }
 
     /**

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
@@ -474,7 +474,7 @@ public class DatadogBuildListener extends RunListener<Run> {
     }
 
     public RunExt getRunExtForRun(WorkflowRun run) {
-        return RunExt.create(run);
+        return RunExt.createNew(run);
     }
 
     public Queue getQueue() {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
@@ -44,6 +44,7 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import org.datadog.jenkins.plugins.datadog.DatadogClient;
 import org.datadog.jenkins.plugins.datadog.DatadogEvent;
+import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration;
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
 import org.datadog.jenkins.plugins.datadog.clients.ClientFactory;
 import org.datadog.jenkins.plugins.datadog.events.BuildAbortedEventImpl;
@@ -474,7 +475,12 @@ public class DatadogBuildListener extends RunListener<Run> {
     }
 
     public RunExt getRunExtForRun(WorkflowRun run) {
-        return RunExt.createNew(run);
+        DatadogGlobalConfiguration cfg = DatadogUtilities.getDatadogGlobalDescriptor();
+        if (cfg.isCacheBuildRuns()) {
+            return RunExt.create(run);
+        } else {
+            return RunExt.createNew(run);
+        }
     }
 
     public Queue getQueue() {

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -120,7 +120,7 @@
         </f:entry>
 
 
-        <f:entry title="Cache Build Runs" description="Cache Build Runs when calculating pause duration">
+        <f:entry title="Cache Build Runs" description="Cache build runs when calculating pause duration">
             <f:checkbox title="Cache Build Runs" field="cacheBuildRuns" default="true" />
         </f:entry>
 

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -119,6 +119,11 @@
             <f:checkbox title="Refresh Dogstatsd Client" field="refreshDogstatsdClient" default="false" />
         </f:entry>
 
+
+        <f:entry title="Cache Build Runs" description="Cache Build Runs when calculating pause duration">
+            <f:checkbox title="Cache Build Runs" field="cacheBuildRuns" default="true" />
+        </f:entry>
+
         <f:entry title="System Events">
           <f:entry description="Send system events like Node changes of states.">
             <f:checkbox title="Send System events" field="emitSystemEvents" default="true" />


### PR DESCRIPTION
### What does this PR do?

This PR adds an option to change the way we fetch a build when calculating pause duration as well as whether we cache the run when fetching it. Now, we don't cache our newly calculated run. Additionally, we create a new RunExt instead of potentially using a cached run.

### Description of the Change

In some cases, caching the run when calculating it caches the incorrect build url

https://github.com/jenkinsci/pipeline-stage-view-plugin/blob/268cddaa96b69d92c06c994c611e0ef55c1bd1db/rest-api/src/main/java/com/cloudbees/workflow/rest/external/RunExt.java#L299

The `create` function first checks if there is a cached run, and if there isn't creates a new run and then caches that run. We are just moving away from this function and using `createNew` to not use the cache.

```
public static RunExt create(WorkflowRun run) {
        FlowExecution execution = run.getExecution();

        // Use cache if eligible
        boolean isNotRunning = FlowNodeUtil.isNotPartOfRunningBuild(execution);
        if (isNotRunning) {
            RunExt myRun = FlowNodeUtil.getCachedRun(run);
            if (myRun != null) {
                return myRun;
            }
        }
        // Compute the entire flow
        RunExt myRun = createNew(run);
        if (isNotRunning) {
            FlowNodeUtil.cacheRun(run, myRun);
        }
        return myRun;
    }
```

### Alternate Designs

### Possible Drawbacks

### Verification Process

Confirm we can still calculate the pause duration metric when using the new version of the plugin

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

