### PR TITLE
Remove "not-recommended" label for Agentless reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This plugin can be installed from the [Update Center][3] (found at `Manage Jenki
 
 There are two ways to configure your plugin to submit data to Datadog:
 
-* **RECOMMENDED**: Using a Datadog Agent that acts as a forwarder between Jenkins and Datadog.
+* Using a Datadog Agent that acts as a forwarder between Jenkins and Datadog.
   - When using a DogStatsD server instead of a full Datadog Agent, only metrics and events are supported.
   - For data submitted from an external host, the Datadog Agent requires the following configuration: `dogstatsd_non_local_traffic: true` and `apm_non_local_traffic: true`. This can be configured using the `datadog.yaml` [configuration file][17].
 * Sending data directly to Datadog through HTTP.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This plugin can be installed from the [Update Center][3] (found at `Manage Jenki
 
 There are two ways to configure your plugin to submit data to Datadog:
 
-* Using a Datadog Agent that acts as a forwarder between Jenkins and Datadog.
+* Using a Datadog Agent that acts as a forwarder between Jenkins and Datadog (recommended).
   - When using a DogStatsD server instead of a full Datadog Agent, only metrics and events are supported.
   - For data submitted from an external host, the Datadog Agent requires the following configuration: `dogstatsd_non_local_traffic: true` and `apm_non_local_traffic: true`. This can be configured using the `datadog.yaml` [configuration file][17].
 * Sending data directly to Datadog through HTTP.

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -14,7 +14,7 @@
   -->
   <f:section title="Datadog Plugin">
 
-    <f:radioBlock title="Use the Datadog Agent to report to Datadog" name="reportWith" value="DSD"
+    <f:radioBlock title="Use the Datadog Agent to report to Datadog (recommended)" name="reportWith" value="DSD"
         checked="${instance.reportWithEquals('DSD')}" inline="true">
 
         <f:entry title="Agent Host" field="targetHostEntry">

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -14,7 +14,7 @@
   -->
   <f:section title="Datadog Plugin">
 
-    <f:radioBlock title="Use the Datadog Agent to report to Datadog (recommended)" name="reportWith" value="DSD"
+    <f:radioBlock title="Use the Datadog Agent to report to Datadog" name="reportWith" value="DSD"
         checked="${instance.reportWithEquals('DSD')}" inline="true">
 
         <f:entry title="Agent Host" field="targetHostEntry">
@@ -38,7 +38,7 @@
         <f:validateButton title="${%Test traces connection}" progress="${%Testing...}" method="checkAgentConnectivityTraces" with="targetHost,targetTraceCollectionPort" />
     </f:radioBlock>
 
-    <f:radioBlock title="Use Datadog API URL and Key to report to Datadog (not recommended)" name="reportWith" value="HTTP"
+    <f:radioBlock title="Use Datadog API URL and Key to report to Datadog" name="reportWith" value="HTTP"
         checked="${instance.reportWithEquals('HTTP')}" inline="true" >
 
         <f:entry title="Datadog API URL" field="targetApiURLEntry" description="URL which the plugin reports to." >
@@ -66,7 +66,7 @@
         <f:checkbox title="Enable Log Collection" field="collectBuildLogs" default="false" />
     </f:entry>
 
-    <f:entry title="CI Visibility (requires Datadog Agent)">
+    <f:entry title="CI Visibility">
         <f:block>
             <table>
               <f:optionalBlock name="ciVisibilityData" field="collectBuildTraces" title="Enable CI Visibility" default="false">


### PR DESCRIPTION
### What does this PR do?

Now that both logs and CI Visibility are supported Agentless, we shouldn't scare users away from it.

### Description of the Change

Should only affect the text labels.

