### PR TITLE
Send webhooks via the Agent EVP Proxy when supported

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogClient.java
@@ -144,6 +144,14 @@ public interface DatadogClient {
     public boolean sendLogs(String payload);
 
     /**
+     * Send a webhook payload to the webhooks intake.
+     *
+     * @param payload - A webhooks payload.
+     * @return a boolean to signify the success or failure of the HTTP POST request.
+     */
+    public boolean postWebhook(String payload);
+
+    /**
      * Start the trace of a certain Jenkins build.
      * @param buildData build data to use in the pipeline trace
      * @param run a particular execution of a Jenkins build

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -1346,7 +1346,6 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
      * Set the checkbox in the UI, used for Jenkins data binding to enable CI Visibility
      *
      * @param enableCiVisibility - The checkbox status (checked/unchecked)
-     * @deprecated Use setEnableCiVisibility
      */
     @DataBoundSetter
     public void setEnableCiVisibility(boolean enableCiVisibility) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
@@ -494,11 +494,11 @@ public class DatadogAgentClient implements DatadogClient {
                 evpProxySupported = supportedAgentEndpoints.contains("/evp_proxy/v3/");
                 lastEvpProxyCheckTimeMs = System.currentTimeMillis();
                 if (evpProxySupported) {
-                    Log.debug("EVP Proxy is supported by the Agent.");
+                    logger.fine("EVP Proxy is supported by the Agent.");
                     traceBuildLogic = new DatadogWebhookBuildLogic(this);
                     tracePipelineLogic = new DatadogWebhookPipelineLogic(this);
                 } else {
-                    Log.info("The Agent doesn't support EVP Proxy, falling back to APM for CI Visibility. Requires Agent v6.42+ or 7.42+.");
+                    logger.info("The Agent doesn't support EVP Proxy, falling back to APM for CI Visibility. Requires Agent v6.42+ or 7.42+.");
                     traceBuildLogic = new DatadogTraceBuildLogic(this.agentHttpClient);
                     tracePipelineLogic = new DatadogTracePipelineLogic(this.agentHttpClient);
                 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
@@ -475,7 +475,7 @@ public class DatadogAgentClient implements DatadogClient {
                     .build();
 
             Set<String> supportedAgentEndpoints = fetchAgentSupportedEndpoints(3);
-            this.evpProxySupported = supportedAgentEndpoints.contains("/evp_proxy/v1/");
+            this.evpProxySupported = supportedAgentEndpoints.contains("/evp_proxy/v3/");
 
             logger.fine("isEvpProxySupported: " + this.evpProxySupported);
 
@@ -483,7 +483,7 @@ public class DatadogAgentClient implements DatadogClient {
                 traceBuildLogic = new DatadogWebhookBuildLogic(this);
                 tracePipelineLogic = new DatadogWebhookPipelineLogic(this);
             } else {
-                Log.warn("The Agent doesn't support EVP Proxy, falling back to APM for CI Visibility. Probably the Agent is older than 6.38/7.38.");
+                Log.info("The Agent doesn't support EVP Proxy, falling back to APM for CI Visibility. Probably the Agent is older than 6.42/7.42.");
                 traceBuildLogic = new DatadogTraceBuildLogic(this.agentHttpClient);
                 tracePipelineLogic = new DatadogTracePipelineLogic(this.agentHttpClient);
             }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
@@ -490,11 +490,12 @@ public class DatadogAgentClient implements DatadogClient {
         }
         synchronized (DatadogAgentClient.class) {
             if (!evpProxySupported) {
+                logger.info("Checking for EVP Proxy support in the Agent.");
                 Set<String> supportedAgentEndpoints = fetchAgentSupportedEndpoints();
                 evpProxySupported = supportedAgentEndpoints.contains("/evp_proxy/v3/");
                 lastEvpProxyCheckTimeMs = System.currentTimeMillis();
                 if (evpProxySupported) {
-                    logger.fine("EVP Proxy is supported by the Agent.");
+                    logger.info("EVP Proxy is supported by the Agent. We will not check again until the next boot.");
                     traceBuildLogic = new DatadogWebhookBuildLogic(this);
                     tracePipelineLogic = new DatadogWebhookPipelineLogic(this);
                 } else {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
@@ -485,7 +485,7 @@ public class DatadogAgentClient implements DatadogClient {
             Set<String> supportedAgentEndpoints = fetchAgentSupportedEndpoints(INFO_NUM_RETRIES);
             this.evpProxySupported = supportedAgentEndpoints.contains("/evp_proxy/v3/");
 
-            logger.fine("isEvpProxySupported: " + this.evpProxySupported);
+            logger.info("EVP Proxy Supported: " + this.evpProxySupported);
 
             if (this.evpProxySupported) {
                 traceBuildLogic = new DatadogWebhookBuildLogic(this);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
@@ -494,6 +494,7 @@ public class DatadogAgentClient implements DatadogClient {
                 evpProxySupported = supportedAgentEndpoints.contains("/evp_proxy/v3/");
                 lastEvpProxyCheckTimeMs = System.currentTimeMillis();
                 if (evpProxySupported) {
+                    Log.debug("EVP Proxy is supported by the Agent.");
                     traceBuildLogic = new DatadogWebhookBuildLogic(this);
                     tracePipelineLogic = new DatadogWebhookPipelineLogic(this);
                 } else {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
@@ -567,10 +567,10 @@ public class DatadogHttpClient implements DatadogClient {
             rd.close();
 
             if ("{}".equals(result.toString())) {
-                logger.fine(String.format("Logs API call was sent successfully!"));
+                logger.fine(String.format("Webhook API call was sent successfully!"));
                 logger.fine(String.format("Payload: %s", payload));
             } else {
-                logger.severe(String.format("Logs API call failed!"));
+                logger.severe(String.format("Webhook API call failed!"));
                 logger.fine(String.format("Payload: %s", payload));
                 return false;
             }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
@@ -600,6 +600,7 @@ public class DatadogHttpClient implements DatadogClient {
      * @return a boolean to signify the success or failure of the HTTP POST request.
      */
     @SuppressFBWarnings("REC_CATCH_EXCEPTION")
+    @Override
     public boolean postWebhook(String payload) {
         logger.fine("Sending webhook");
         if(this.isWebhookIntakeConnectionBroken()){

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogHttpClient.java
@@ -567,10 +567,10 @@ public class DatadogHttpClient implements DatadogClient {
             rd.close();
 
             if ("{}".equals(result.toString())) {
-                logger.fine(String.format("Webhook API call was sent successfully!"));
+                logger.fine(String.format("Logs API call was sent successfully!"));
                 logger.fine(String.format("Payload: %s", payload));
             } else {
-                logger.severe(String.format("Webhook API call failed!"));
+                logger.severe(String.format("Logs API call failed!"));
                 logger.fine(String.format("Payload: %s", payload));
                 return false;
             }
@@ -630,10 +630,10 @@ public class DatadogHttpClient implements DatadogClient {
             rd.close();
 
             if ("{}".equals(result.toString())) {
-                logger.fine(String.format("Logs API call was sent successfully!"));
+                logger.fine(String.format("Webhook API call was sent successfully!"));
                 logger.fine(String.format("Payload: %s", payload));
             } else {
-                logger.severe(String.format("Logs API call failed!"));
+                logger.severe(String.format("Webhook API call failed!"));
                 logger.fine(String.format("Payload: %s", payload));
                 return false;
             }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
@@ -21,12 +21,14 @@ import hudson.model.Run;
 /**
  * Base class for DatadogTraceBuildLogic and DatadogPipelineBuildLogic
  */
-public class DatadogBaseBuildLogic {
+public abstract class DatadogBaseBuildLogic {
 
     protected static final String HOSTNAME_NONE = "none";
     private static final int MAX_TAG_LENGTH = 5000;
     private static final Logger logger = Logger.getLogger(DatadogBaseBuildLogic.class.getName());
 
+    public abstract void finishBuildTrace(final BuildData buildData, final Run<?,?> run);
+    public abstract void startBuildTrace(final BuildData buildData, Run run);
 
     protected String getNodeName(Run<?, ?> run, BuildData buildData, BuildData updatedBuildData) {
         final PipelineNodeInfoAction pipelineNodeInfoAction = run.getAction(PipelineNodeInfoAction.class);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBasePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBasePipelineLogic.java
@@ -47,11 +47,13 @@ import hudson.model.TaskListener;
 /**
  * Base class with shared code for DatadogTracePipelineLogic and DatadogWebhookPipelineLogic
  */
-public class DatadogBasePipelineLogic {
+public abstract class DatadogBasePipelineLogic {
 
     protected static final String CI_PROVIDER = "jenkins";
     protected static final String HOSTNAME_NONE = "none";
     private static final Logger logger = Logger.getLogger(DatadogBasePipelineLogic.class.getName());
+
+    public abstract void execute(Run run, FlowNode flowNode);
 
     protected BuildPipelineNode buildPipelineTree(FlowEndNode flowEndNode) {
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
@@ -40,6 +40,7 @@ public class DatadogTraceBuildLogic extends DatadogBaseBuildLogic {
         this.agentHttpClient = agentHttpClient;
     }
 
+    @Override
     public void startBuildTrace(final BuildData buildData, Run run) {
         if (!DatadogUtilities.getDatadogGlobalDescriptor().getEnableCiVisibility()) {
             logger.fine("CI Visibility is disabled");
@@ -80,6 +81,7 @@ public class DatadogTraceBuildLogic extends DatadogBaseBuildLogic {
         run.addAction(ciGlobalTags);
     }
 
+    @Override
     public void finishBuildTrace(final BuildData buildData, final Run<?,?> run) {
         if (!DatadogUtilities.getDatadogGlobalDescriptor().getEnableCiVisibility()) {
             return;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
@@ -153,35 +153,6 @@ public class DatadogTracePipelineLogic extends DatadogBasePipelineLogic {
         spanBuffer.add(span);
     }
 
-    private void updateStageBreakdown(final Run<?,?> run, BuildPipelineNode pipelineNode) {
-        long start = System.currentTimeMillis();
-        try {
-            final StageBreakdownAction stageBreakdownAction = run.getAction(StageBreakdownAction.class);
-            if(stageBreakdownAction == null){
-                return;
-            }
-
-            if(pipelineNode == null){
-                return;
-            }
-
-            if(!BuildPipelineNode.NodeType.STAGE.equals(pipelineNode.getType())){
-                return;
-            }
-
-            final StageData stageData = StageData.builder()
-                    .withName(pipelineNode.getName())
-                    .withStartTimeInMicros(pipelineNode.getStartTimeMicros())
-                    .withEndTimeInMicros(pipelineNode.getEndTimeMicros())
-                    .build();
-
-            stageBreakdownAction.put(stageData.getName(), stageData);
-        } finally {
-            long end = System.currentTimeMillis();
-            DatadogAudit.log("DatadogTracePipelineLogic.updateStageBreakdown", start, end);
-        }
-    }
-
     private Map<String, Long> buildTraceMetrics(BuildPipelineNode current) {
         final Map<String, Long> metrics = new HashMap<>();
         metrics.put(CITags.QUEUE_TIME, TimeUnit.NANOSECONDS.toSeconds(getNanosInQueue(current)));

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
@@ -48,6 +48,7 @@ public class DatadogTracePipelineLogic extends DatadogBasePipelineLogic {
         this.agentHttpClient = agentHttpClient;
     }
 
+    @Override
     public void execute(Run run, FlowNode flowNode) {
 
         if (!DatadogUtilities.getDatadogGlobalDescriptor().getEnableCiVisibility()) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -284,6 +284,8 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
 
             if (gitPayload.keySet().containsAll(GitUtils.WEBHOOK_REQUIRED_GIT_KEYS)) {
                 payload.put("git", gitPayload);
+            } else {
+                logger.warning("Couldn't fetch all git metadata");
             }
         }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -285,7 +285,7 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
             if (gitPayload.keySet().containsAll(GitUtils.WEBHOOK_REQUIRED_GIT_KEYS)) {
                 payload.put("git", gitPayload);
             } else {
-                logger.warning("Couldn't fetch all git metadata");
+                logger.info("Couldn't fetch all required git metadata, git metadata won't be reported");
             }
         }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -15,8 +15,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
+import org.datadog.jenkins.plugins.datadog.DatadogClient;
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
-import org.datadog.jenkins.plugins.datadog.clients.DatadogHttpClient;
 import org.datadog.jenkins.plugins.datadog.model.BuildData;
 import org.datadog.jenkins.plugins.datadog.model.BuildPipelineNode;
 import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
@@ -37,12 +37,13 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
 
     private static final Logger logger = Logger.getLogger(DatadogWebhookBuildLogic.class.getName());
 
-    private final DatadogHttpClient client;
+    private final DatadogClient client;
 
-    public DatadogWebhookBuildLogic(final DatadogHttpClient client) {
+    public DatadogWebhookBuildLogic(final DatadogClient client) {
         this.client = client;
     }
 
+    @Override
     public void startBuildTrace(final BuildData buildData, Run run) {
         if (!DatadogUtilities.getDatadogGlobalDescriptor().getEnableCiVisibility()) {
             logger.fine("CI Visibility is disabled");
@@ -71,6 +72,7 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
         run.addAction(ciGlobalTags);
     }
 
+    @Override
     public void finishBuildTrace(final BuildData buildData, final Run<?,?> run) {
         if (!DatadogUtilities.getDatadogGlobalDescriptor().getEnableCiVisibility()) {
             return;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
@@ -110,8 +110,10 @@ public class DatadogWebhookPipelineLogic extends DatadogBasePipelineLogic {
         payload.put("partial_retry", false);
         payload.put("queue_time", TimeUnit.NANOSECONDS.toMillis(getNanosInQueue(current)));
         payload.put("status", status);
+
         payload.put("trace_id", spanContext.getTraceId());
         payload.put("span_id", spanContext.getSpanId());
+        payload.put("parent_span_id", spanContext.getParentId());
 
         payload.put("id", current.getId());
         payload.put("name", current.getName());
@@ -120,16 +122,12 @@ public class DatadogWebhookPipelineLogic extends DatadogBasePipelineLogic {
         payload.put("pipeline_name", buildData.getBaseJobName(""));
         if (buildLevel.equals("stage")) {
             if (parent != null && parent.getType().getBuildLevel() == "stage") {
-                // Stage is a parent of another stage
+                // Stage is a child of another stage
                 payload.put("parent_stage_id", parent.getStageId());
-                payload.put("parent_span_id", parent.getSpanId());
             }
         } else if (buildLevel.equals("job")) {
             payload.put("stage_id", current.getStageId());
             payload.put("stage_name", current.getStageName());
-            if (parent != null) {
-                payload.put("parent_span_id", parent.getSpanId());
-            }
         }
 
         // Errors

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
@@ -61,6 +61,7 @@ public class DatadogWebhookPipelineLogic extends DatadogBasePipelineLogic {
         final BuildData buildData = buildSpanAction.getBuildData();
         if(!isLastNode(flowNode)){
             final BuildPipelineNode pipelineNode = buildPipelineNode(flowNode);
+            updateStageBreakdown(run, pipelineNode);
             updateBuildData(buildData, run, pipelineNode, flowNode);
             updateCIGlobalTags(run);
             return;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
@@ -15,8 +15,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
+import org.datadog.jenkins.plugins.datadog.DatadogClient;
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
-import org.datadog.jenkins.plugins.datadog.clients.DatadogHttpClient;
 import org.datadog.jenkins.plugins.datadog.model.BuildData;
 import org.datadog.jenkins.plugins.datadog.model.BuildPipelineNode;
 import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
@@ -35,12 +35,13 @@ import net.sf.json.JSONObject;
  */
 public class DatadogWebhookPipelineLogic extends DatadogBasePipelineLogic {
 
-    private final DatadogHttpClient client;
+    private final DatadogClient client;
 
-    public DatadogWebhookPipelineLogic(final DatadogHttpClient client) {
+    public DatadogWebhookPipelineLogic(final DatadogClient client) {
         this.client = client;
     }
 
+    @Override
     public void execute(Run run, FlowNode flowNode) {
 
         if (!DatadogUtilities.getDatadogGlobalDescriptor().getEnableCiVisibility()) {

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
@@ -177,6 +177,13 @@ public class DatadogClientStub implements DatadogClient {
     }
 
     @Override
+    public boolean postWebhook(String webhook) {
+        JSONObject payload = JSONObject.fromObject(webhook);
+        this.logLines.add(payload);
+        return true;
+    }
+
+    @Override
     public boolean startBuildTrace(BuildData buildData, Run<?, ?> run) {
         this.traceBuildLogic.startBuildTrace(buildData, run);
         return true;

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientStub.java
@@ -31,8 +31,12 @@ import net.sf.json.JSONObject;
 import org.datadog.jenkins.plugins.datadog.DatadogClient;
 import org.datadog.jenkins.plugins.datadog.DatadogEvent;
 import org.datadog.jenkins.plugins.datadog.model.BuildData;
+import org.datadog.jenkins.plugins.datadog.traces.DatadogBaseBuildLogic;
+import org.datadog.jenkins.plugins.datadog.traces.DatadogBasePipelineLogic;
 import org.datadog.jenkins.plugins.datadog.traces.DatadogTraceBuildLogic;
 import org.datadog.jenkins.plugins.datadog.traces.DatadogTracePipelineLogic;
+import org.datadog.jenkins.plugins.datadog.traces.DatadogWebhookBuildLogic;
+import org.datadog.jenkins.plugins.datadog.traces.DatadogWebhookPipelineLogic;
 import org.datadog.jenkins.plugins.datadog.transport.FakeTracesHttpClient;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.junit.Assert;
@@ -44,6 +48,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class DatadogClientStub implements DatadogClient {
 
@@ -51,17 +57,23 @@ public class DatadogClientStub implements DatadogClient {
     public List<DatadogMetric> serviceChecks;
     public List<DatadogEventStub> events;
     public List<JSONObject> logLines;
+    public List<JSONObject> webhooks;
+
+    private List<CountDownLatch> webhookLatches;
 
     public FakeTracesHttpClient agentHttpClient;
 
-    public DatadogTraceBuildLogic traceBuildLogic;
-    public DatadogTracePipelineLogic tracePipelineLogic;
+    public DatadogBaseBuildLogic traceBuildLogic;
+    public DatadogBasePipelineLogic tracePipelineLogic;
+
 
     public DatadogClientStub() {
         this.metrics = new ArrayList<>();
         this.serviceChecks = new ArrayList<>();
         this.events = new ArrayList<>();
         this.logLines = new ArrayList<>();
+        this.webhooks = new ArrayList<>();
+        this.webhookLatches = new ArrayList<>();
         this.agentHttpClient = new FakeTracesHttpClient();
         this.traceBuildLogic = new DatadogTraceBuildLogic(this.agentHttpClient);
         this.tracePipelineLogic = new DatadogTracePipelineLogic(this.agentHttpClient);
@@ -178,8 +190,17 @@ public class DatadogClientStub implements DatadogClient {
 
     @Override
     public boolean postWebhook(String webhook) {
-        JSONObject payload = JSONObject.fromObject(webhook);
-        this.logLines.add(payload);
+        synchronized (webhookLatches) {
+            JSONObject payload = JSONObject.fromObject(webhook);
+            webhooks.add(payload);
+            for(final CountDownLatch latch : webhookLatches) {
+                if(webhooks.size() >= latch.getCount()) {
+                    while (latch.getCount() > 0) {
+                        latch.countDown();
+                    }
+                }
+            }
+        }
         return true;
     }
 
@@ -339,6 +360,26 @@ public class DatadogClientStub implements DatadogClient {
         v.add(value);
         tags.put(name, v);
         return tags;
+    }
+
+    public void configureForWebhooks() {
+        traceBuildLogic = new DatadogWebhookBuildLogic(this);
+        tracePipelineLogic = new DatadogWebhookPipelineLogic(this);
+    }
+
+    public boolean waitForWebhooks(final int number) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(number);
+        synchronized (webhookLatches) {
+            if (webhooks.size() >= number) {
+                return true;
+            }
+            webhookLatches.add(latch);
+        }
+        return latch.await(10, TimeUnit.SECONDS);
+    }
+
+    public List<JSONObject> getWebhooks() {
+        return this.webhooks;
     }
 
 }

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
@@ -137,6 +137,17 @@ public class DatadogClientTest {
     }
 
     @Test
+    public void testEmptyAgentSupportedEndpointsWithNoAgent() {
+        DatadogGlobalConfiguration cfg = DatadogUtilities.getDatadogGlobalDescriptor();
+        cfg.setEnableCiVisibility(true);
+        DatadogAgentClient client = Mockito.mock(DatadogAgentClient.class);
+        when(client.getHostname()).thenReturn("test");
+        when(client.getTraceCollectionPort()).thenReturn(1234);
+        when(client.fetchAgentSupportedEndpoints(Mockito.anyInt())).thenCallRealMethod();
+        Assert.assertTrue(client.fetchAgentSupportedEndpoints(0).isEmpty());
+    }
+
+    @Test
     public void testIncrementCountAndFlush() throws IOException, InterruptedException {
         DatadogHttpClient.enableValidations = false;
         DatadogClient client = DatadogHttpClient.getInstance("test", null, null, null);

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
@@ -115,7 +115,7 @@ public class DatadogClientTest {
         DatadogAgentClient client = Mockito.mock(DatadogAgentClient.class);
         when(client.getHostname()).thenReturn("test");
         when(client.getTraceCollectionPort()).thenReturn(1234);
-        when(client.fetchAgentSupportedEndpoints()).thenReturn(new HashSet<String>(Arrays.asList("/evp_proxy/v1/")));
+        when(client.fetchAgentSupportedEndpoints(Mockito.anyInt())).thenReturn(new HashSet<String>(Arrays.asList("/evp_proxy/v1/")));
         when(client.reinitializeAgentHttpClient(Mockito.anyBoolean())).thenCallRealMethod();
         when(client.isEvpProxySupported()).thenCallRealMethod();
         client.reinitializeAgentHttpClient(true);
@@ -129,7 +129,7 @@ public class DatadogClientTest {
         DatadogAgentClient client = Mockito.mock(DatadogAgentClient.class);
         when(client.getHostname()).thenReturn("test");
         when(client.getTraceCollectionPort()).thenReturn(1234);
-        when(client.fetchAgentSupportedEndpoints()).thenReturn(new HashSet<String>());
+        when(client.fetchAgentSupportedEndpoints(Mockito.anyInt())).thenReturn(new HashSet<String>());
         when(client.reinitializeAgentHttpClient(Mockito.anyBoolean())).thenCallRealMethod();
         when(client.isEvpProxySupported()).thenCallRealMethod();
         client.reinitializeAgentHttpClient(true);

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
@@ -42,8 +42,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.*;
 
-import static org.mockito.Mockito.when;
-
 public class DatadogClientTest {
 
     @ClassRule
@@ -112,39 +110,26 @@ public class DatadogClientTest {
     public void testEvpProxyEnabled() {
         DatadogGlobalConfiguration cfg = DatadogUtilities.getDatadogGlobalDescriptor();
         cfg.setEnableCiVisibility(true);
-        DatadogAgentClient client = Mockito.mock(DatadogAgentClient.class);
-        when(client.getHostname()).thenReturn("test");
-        when(client.getTraceCollectionPort()).thenReturn(1234);
-        when(client.fetchAgentSupportedEndpoints(Mockito.anyInt())).thenReturn(new HashSet<String>(Arrays.asList("/evp_proxy/v3/")));
-        when(client.reinitializeAgentHttpClient(Mockito.anyBoolean())).thenCallRealMethod();
-        when(client.isEvpProxySupported()).thenCallRealMethod();
-        client.reinitializeAgentHttpClient(true);
-        Assert.assertTrue(client.isEvpProxySupported());
+        DatadogAgentClient client = Mockito.spy(new DatadogAgentClient("test",1234, 1235, 1236));
+        Mockito.doReturn(new HashSet<String>(Arrays.asList("/evp_proxy/v3/"))).when(client).fetchAgentSupportedEndpoints();
+        Assert.assertTrue(client.checkEvpProxySupportAndUpdateLogic());
     }
 
     @Test
     public void testEvpProxyDisabled() {
         DatadogGlobalConfiguration cfg = DatadogUtilities.getDatadogGlobalDescriptor();
         cfg.setEnableCiVisibility(true);
-        DatadogAgentClient client = Mockito.mock(DatadogAgentClient.class);
-        when(client.getHostname()).thenReturn("test");
-        when(client.getTraceCollectionPort()).thenReturn(1234);
-        when(client.fetchAgentSupportedEndpoints(Mockito.anyInt())).thenReturn(new HashSet<String>());
-        when(client.reinitializeAgentHttpClient(Mockito.anyBoolean())).thenCallRealMethod();
-        when(client.isEvpProxySupported()).thenCallRealMethod();
-        client.reinitializeAgentHttpClient(true);
-        Assert.assertFalse(client.isEvpProxySupported());
+        DatadogAgentClient client = Mockito.spy(new DatadogAgentClient("test",1234, 1235, 1236));
+        Mockito.doReturn(new HashSet<String>()).when(client).fetchAgentSupportedEndpoints();
+        Assert.assertFalse(client.checkEvpProxySupportAndUpdateLogic());
     }
 
     @Test
     public void testEmptyAgentSupportedEndpointsWithNoAgent() {
         DatadogGlobalConfiguration cfg = DatadogUtilities.getDatadogGlobalDescriptor();
         cfg.setEnableCiVisibility(true);
-        DatadogAgentClient client = Mockito.mock(DatadogAgentClient.class);
-        when(client.getHostname()).thenReturn("test");
-        when(client.getTraceCollectionPort()).thenReturn(1234);
-        when(client.fetchAgentSupportedEndpoints(Mockito.anyInt())).thenCallRealMethod();
-        Assert.assertTrue(client.fetchAgentSupportedEndpoints(0).isEmpty());
+        DatadogAgentClient client = new DatadogAgentClient("test", 1234, 1235, 1236);
+        Assert.assertTrue(client.fetchAgentSupportedEndpoints().isEmpty());
     }
 
     @Test

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
@@ -115,7 +115,7 @@ public class DatadogClientTest {
         DatadogAgentClient client = Mockito.mock(DatadogAgentClient.class);
         when(client.getHostname()).thenReturn("test");
         when(client.getTraceCollectionPort()).thenReturn(1234);
-        when(client.fetchAgentSupportedEndpoints(Mockito.anyInt())).thenReturn(new HashSet<String>(Arrays.asList("/evp_proxy/v1/")));
+        when(client.fetchAgentSupportedEndpoints(Mockito.anyInt())).thenReturn(new HashSet<String>(Arrays.asList("/evp_proxy/v3/")));
         when(client.reinitializeAgentHttpClient(Mockito.anyBoolean())).thenCallRealMethod();
         when(client.isEvpProxySupported()).thenCallRealMethod();
         client.reinitializeAgentHttpClient(true);

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogTraceAbstractTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogTraceAbstractTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import hudson.model.Run;
+import net.sf.json.JSONObject;
 import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
 import org.datadog.jenkins.plugins.datadog.model.GitCommitAction;
 import org.datadog.jenkins.plugins.datadog.model.GitRepositoryAction;
@@ -23,7 +24,7 @@ import static org.junit.Assert.*;
 
 public abstract class DatadogTraceAbstractTest {
 
-    protected void assertGitVariables(TraceSpan span, String defaultBranch) {
+    protected void assertGitVariablesOnSpan(TraceSpan span, String defaultBranch) {
         final Map<String, String> meta = span.getMeta();
         assertEquals("Initial commit\n", meta.get(CITags.GIT_COMMIT_MESSAGE));
         assertEquals("John Doe", meta.get(CITags.GIT_COMMIT_AUTHOR_NAME));
@@ -37,6 +38,21 @@ public abstract class DatadogTraceAbstractTest {
         assertEquals("master", meta.get(CITags.GIT_BRANCH));
         assertEquals("https://github.com/johndoe/foobar.git", meta.get(CITags.GIT_REPOSITORY_URL));
         assertEquals(defaultBranch, meta.get(CITags.GIT_DEFAULT_BRANCH));
+    }
+
+    protected void assertGitVariablesOnWebhook(JSONObject webhook, String defaultBranch) {
+        JSONObject meta = webhook.getJSONObject("git");
+        assertEquals("Initial commit\n", meta.get("message"));
+        assertEquals("John Doe", meta.get("author_name"));
+        assertEquals("john@doe.com", meta.get("author_email"));
+        assertEquals("2020-10-08T07:49:32.000Z", meta.get("author_time"));
+        assertEquals("John Doe", meta.get("committer_name"));
+        assertEquals("john@doe.com", meta.get("committer_email"));
+        assertEquals("2020-10-08T07:49:32.000Z", meta.get("commit_time"));
+        assertEquals("401d997a6eede777602669ccaec059755c98161f", meta.get("sha"));
+        assertEquals("master", meta.get("branch"));
+        assertEquals("https://github.com/johndoe/foobar.git", meta.get("repository_url"));
+        assertEquals(defaultBranch, meta.get("default_branch"));
     }
 
     protected void assertCleanupActions(Run<?,?> run) {

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineOnWorkersWebhook.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineOnWorkersWebhook.txt
@@ -1,0 +1,12 @@
+pipeline {
+    agent {
+        label "testPipelineWorkerWebhook"
+    }
+    stages {
+        stage('testing'){
+            steps {
+                echo "testing"
+            }
+        }
+    }
+}

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineStagesWebhook.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineStagesWebhook.txt
@@ -1,0 +1,27 @@
+pipeline {
+    agent none
+    stages {
+        stage('Run stages') {
+            parallel {
+                stage('Stage 1') {
+                        agent {
+                            label('testStageNameWebhook')
+                        }
+
+                        steps {
+                            echo "testing 1"
+                        }
+                }
+                stage('Stage 2') {
+                    agent {
+                        label('testStageNameWebhook')
+                    }
+
+                    steps {
+                        echo "testing 2"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- Checks whether the Agent supports the EVP Proxy endpoint.
- If it does, it generates webhooks instead of traces and sends them using the EVP Proxy.
- If it doesn't, continues to generate traces and send them via APM.

I also added tests for the whole webhooks logic, which didn't have any. They are mostly copies of the tests for the traces logic.

### Description of the Change

- Adds a `fetchAgentSupportedEndpoints()` method to `DatadogAgentClient` that queries the `/info` Agent API.
- Makes the `postWebhook()` method part of the abstract `DatadogClient` so that `DatadogWebhookBuildLogic` and `DatadogWebhookPipelineLogic` can call it on either a `DatadogAgentClient` or a `DatadogHttpClient` instance.
- Implements `postWebhook()` in `DatadogAgentClient`. It sends webhook-type payloads using the Agent EVP Proxy.
- The public methods in `DatadogTraceBuildLogic` and `DatadogWebhookBuildLogic` are now `@Override`s of abstract methods of their parent `DatadogBaseBuildLogic` so `DatadogAgentClient` can use either implementation (depending on the output of `fetchAgentSupportedEndpoints`). Same for `Datadog*PipelineLogic`.

### Verification Process

- Test against an Agent that supports EVP Proxy and one that doesn't

### Open Questions

* If Jenkins starts before the Agent, then the EVP Proxy support will be disabled because we won't be able to query the `/info` API when initializing the `DatadogAgentClient`. Is this okay?
   * ~I've added 3 retries at startup time to wait for the Agent.~
   * I've made checking the /info endpoint lazy. See my comment below.
