### PR TITLE
Webhooks: Do not drop partial git info

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -282,11 +282,7 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
                 gitPayload.put("default_branch", gitDefaultBranch);
             }
 
-            if (gitPayload.keySet().containsAll(GitUtils.WEBHOOK_REQUIRED_GIT_KEYS)) {
-                payload.put("git", gitPayload);
-            } else {
-                logger.info("Couldn't fetch all required git metadata, git metadata won't be reported");
-            }
+            payload.put("git", gitPayload);
         }
 
         client.postWebhook(payload.toString());

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
@@ -254,9 +254,7 @@ public class DatadogWebhookPipelineLogic extends DatadogBasePipelineLogic {
                 gitPayload.put("default_branch", gitDefaultBranch);
             }
 
-            if (gitPayload.keySet().containsAll(GitUtils.WEBHOOK_REQUIRED_GIT_KEYS)) {
-                payload.put("git", gitPayload);
-            }
+            payload.put("git", gitPayload);
         }
 
         // Tags

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/util/git/GitUtils.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/util/git/GitUtils.java
@@ -44,8 +44,6 @@ public final class GitUtils {
     private static transient final Pattern SHA1_PATTERN = Pattern.compile("\\b[a-f0-9]{40}\\b");
     private static transient final Pattern SCP_REPO_URI_REGEX = Pattern.compile("^([\\w.~-]+@)?(?<host>[\\w.-]+):(?<path>[\\w./-]+)(?:\\?|$)(.*)$");
 
-    public static final Collection<String> WEBHOOK_REQUIRED_GIT_KEYS = Collections.unmodifiableList(Arrays.asList("repository_url", "message","sha","commit_time","author_time","committer_name","author_name","committer_email","author_email"));
-
     private GitUtils(){}
 
     /**


### PR DESCRIPTION
### What does this PR do?

Removes the check that would not include git metadata if it was incomplete.

### Motivation

We have relaxed the requirements on complete git info from the backend.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

