### PR TITLE
Fix flaky test

### DIFF
--- a/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/clients/DatadogClientTest.java
@@ -292,7 +292,7 @@ public class DatadogClientTest {
     private static void stop(ExecutorService executor) {
         try {
             executor.shutdown();
-            executor.awaitTermination(3, TimeUnit.SECONDS);
+            executor.awaitTermination(5, TimeUnit.SECONDS);
         }
         catch (InterruptedException e) {
             System.err.println("termination interrupted");

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogQueuePipelinePublisherTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogQueuePipelinePublisherTest.java
@@ -39,13 +39,13 @@ public class DatadogQueuePipelinePublisherTest {
         QueueTaskFuture<WorkflowRun> task = job.scheduleBuild2(0);
         Queue queue = jenkins.jenkins.getQueue();
         for (int i = 0; i < 10; i++) {
+            Thread.sleep(500);
             if (!queue.getBuildableItems().isEmpty()) {
                 String name  = queue.getBuildableItems().get(0).task.getFullDisplayName();
                 if (name != null & name.contains("pipelineIntegrationQueue")) {
                     break;
                 }
             }
-            Thread.sleep(500);
         }
 
         final String[] expectedTags = new String[2];


### PR DESCRIPTION
### What does this PR do?

Hopefully fix `testPipelineInQueue` which was flaky.

We still have other flaky tests, though.

### Description of the Change

Make the sleep happen before the break clause.
