### PR TITLE
Fix hostname resolution in recent Jenkins versions

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -638,6 +638,10 @@ public class DatadogUtilities {
         }
     }
 
+    public static boolean isMainNode(String nodeName){
+        return "master".equalsIgnoreCase(nodeName) || "built-in".equalsIgnoreCase(nodeName);
+    }
+
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public static Set<String> getNodeLabels(Computer computer) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
@@ -70,7 +70,7 @@ public abstract class DatadogBaseBuildLogic {
 
             // If there is no labels and the node name is master,
             // we force the label "master".
-            if("master".equalsIgnoreCase(nodeName)){
+            if("master".equalsIgnoreCase(nodeName) || "built-in".equalsIgnoreCase(nodeName)) {
                 final Set<String> masterLabels = new HashSet<>();
                 masterLabels.add("master");
                 return masterLabels;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
@@ -70,7 +70,7 @@ public abstract class DatadogBaseBuildLogic {
 
             // If there is no labels and the node name is master,
             // we force the label "master".
-            if("master".equalsIgnoreCase(nodeName) || "built-in".equalsIgnoreCase(nodeName)) {
+            if(DatadogUtilities.isMainNode(nodeName)) {
                 final Set<String> masterLabels = new HashSet<>();
                 masterLabels.add("master");
                 return masterLabels;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBasePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBasePipelineLogic.java
@@ -238,7 +238,7 @@ public abstract class DatadogBasePipelineLogic {
 
         // If there is no labels and the node name is master,
         // we force the label "master".
-        if ("master".equalsIgnoreCase(nodeName)) {
+        if ("master".equalsIgnoreCase(nodeName) || "built-in".equalsIgnoreCase(nodeName)) {
             final Set<String> masterLabels = new HashSet<>();
             masterLabels.add("master");
             return masterLabels;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBasePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBasePipelineLogic.java
@@ -238,7 +238,7 @@ public abstract class DatadogBasePipelineLogic {
 
         // If there is no labels and the node name is master,
         // we force the label "master".
-        if ("master".equalsIgnoreCase(nodeName) || "built-in".equalsIgnoreCase(nodeName)) {
+        if (DatadogUtilities.isMainNode(nodeName)) {
             final Set<String> masterLabels = new HashSet<>();
             masterLabels.add("master");
             return masterLabels;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
@@ -140,7 +140,7 @@ public class DatadogTraceBuildLogic extends DatadogBaseBuildLogic {
         }
 
         // If the NodeName == "master", we don't set _dd.hostname. It will be overridden by the Datadog Agent. (Traces are only available using Datadog Agent)
-        if(!"master".equalsIgnoreCase(nodeName)){
+        if(!"master".equalsIgnoreCase(nodeName) && !"built-in".equalsIgnoreCase(nodeName)) {
             final String workerHostname = getNodeHostname(run, updatedBuildData);
             // If the worker hostname is equals to controller hostname but the node name is not "master"
             // then we could not detect the worker hostname properly. We set _dd.hostname to 'none' explicitly.

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
@@ -140,7 +140,7 @@ public class DatadogTraceBuildLogic extends DatadogBaseBuildLogic {
         }
 
         // If the NodeName == "master", we don't set _dd.hostname. It will be overridden by the Datadog Agent. (Traces are only available using Datadog Agent)
-        if(!"master".equalsIgnoreCase(nodeName) && !"built-in".equalsIgnoreCase(nodeName)) {
+        if(!DatadogUtilities.isMainNode(nodeName)) {
             final String workerHostname = getNodeHostname(run, updatedBuildData);
             // If the worker hostname is equals to controller hostname but the node name is not "master"
             // then we could not detect the worker hostname properly. We set _dd.hostname to 'none' explicitly.

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
@@ -246,7 +246,7 @@ public class DatadogTracePipelineLogic extends DatadogBasePipelineLogic {
         }
 
         // If the NodeName == "master", we don't set _dd.hostname. It will be overridden by the Datadog Agent. (Traces are only available using Datadog Agent)
-        if(!"master".equalsIgnoreCase(nodeName) && !"built-in".equalsIgnoreCase(nodeName)) {
+        if(!DatadogUtilities.isMainNode(nodeName)) {
             final String workerHostname = getNodeHostname(run, current);
             // If the worker hostname is equals to controller hostname but the node name is not "master"
             // then we could not detect the worker hostname properly. We set _dd.hostname to 'none' explicitly.

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
@@ -246,7 +246,7 @@ public class DatadogTracePipelineLogic extends DatadogBasePipelineLogic {
         }
 
         // If the NodeName == "master", we don't set _dd.hostname. It will be overridden by the Datadog Agent. (Traces are only available using Datadog Agent)
-        if(!"master".equalsIgnoreCase(nodeName)){
+        if(!"master".equalsIgnoreCase(nodeName) && !"built-in".equalsIgnoreCase(nodeName)) {
             final String workerHostname = getNodeHostname(run, current);
             // If the worker hostname is equals to controller hostname but the node name is not "master"
             // then we could not detect the worker hostname properly. We set _dd.hostname to 'none' explicitly.

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -194,7 +194,7 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
 
             final String nodeName = getNodeName(run, buildData, updatedBuildData);
             nodePayload.put("name", nodeName);
-            if(!"master".equalsIgnoreCase(nodeName) && !"built-in".equalsIgnoreCase(nodeName)) {
+            if(!DatadogUtilities.isMainNode(nodeName)) {
 
                 final String workerHostname = getNodeHostname(run, updatedBuildData);
                 // If the worker hostname is equals to controller hostname but the node name is not "master"

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -194,8 +194,8 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
 
             final String nodeName = getNodeName(run, buildData, updatedBuildData);
             nodePayload.put("name", nodeName);
+            if(!"master".equalsIgnoreCase(nodeName) && !"built-in".equalsIgnoreCase(nodeName)) {
 
-            if(!"master".equalsIgnoreCase(nodeName)){
                 final String workerHostname = getNodeHostname(run, updatedBuildData);
                 // If the worker hostname is equals to controller hostname but the node name is not "master"
                 // then we could not detect the worker hostname properly. We set _dd.hostname to 'none' explicitly.

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
@@ -153,7 +153,7 @@ public class DatadogWebhookPipelineLogic extends DatadogBasePipelineLogic {
             final String nodeName = getNodeName(run, current, buildData);
             nodePayload.put("name", nodeName);
 
-            if(!"master".equalsIgnoreCase(nodeName) && !"built-in".equalsIgnoreCase(nodeName)) {
+            if(!DatadogUtilities.isMainNode(nodeName)) {
                 final String workerHostname = getNodeHostname(run, current);
                 // If the worker hostname is equals to controller hostname but the node name is not "master"
                 // then we could not detect the worker hostname properly. We set _dd.hostname to 'none' explicitly.

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
@@ -153,7 +153,7 @@ public class DatadogWebhookPipelineLogic extends DatadogBasePipelineLogic {
             final String nodeName = getNodeName(run, current, buildData);
             nodePayload.put("name", nodeName);
 
-            if(!"master".equalsIgnoreCase(nodeName)){
+            if(!"master".equalsIgnoreCase(nodeName) && !"built-in".equalsIgnoreCase(nodeName)) {
                 final String workerHostname = getNodeHostname(run, current);
                 // If the worker hostname is equals to controller hostname but the node name is not "master"
                 // then we could not detect the worker hostname properly. We set _dd.hostname to 'none' explicitly.

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/util/git/GitUtils.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/util/git/GitUtils.java
@@ -59,7 +59,7 @@ public final class GitUtils {
         }
 
         try {
-            return "master".equals(nodeName) ? new FilePath(FilePath.localChannel, workspace):  FilePathUtils.find(nodeName, workspace);
+            return ("master".equals(nodeName) || "built-in".equals(nodeName)) ? new FilePath(FilePath.localChannel, workspace):  FilePathUtils.find(nodeName, workspace);
         } catch (Exception e) {
             LOGGER.fine("Unable to build FilePath. Error: " + e);
             return null;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/util/git/GitUtils.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/util/git/GitUtils.java
@@ -59,7 +59,7 @@ public final class GitUtils {
         }
 
         try {
-            return ("master".equals(nodeName) || "built-in".equals(nodeName)) ? new FilePath(FilePath.localChannel, workspace):  FilePathUtils.find(nodeName, workspace);
+            return DatadogUtilities.isMainNode(nodeName) ? new FilePath(FilePath.localChannel, workspace):  FilePathUtils.find(nodeName, workspace);
         } catch (Exception e) {
             LOGGER.fine("Unable to build FilePath. Error: " + e);
             return null;

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/help-hostnameEntry.html
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/help-hostnameEntry.html
@@ -1,3 +1,3 @@
 <div>
-    Enter the name you'd like to identify your Jenkins host as. Must comply with the hostname format set in <a target="_blank" href="https://tools.ietf.org/html/rfc1123#section-2">RFC 1123</a>.
+    Enter the name you'd like to identify your Jenkins host as. Must comply with the hostname format set in <a target="_blank" href="https://tools.ietf.org/html/rfc1123#section-2">RFC 1123</a>. Leave empty to use the detected hostname.
 </div>

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogTraceAbstractTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogTraceAbstractTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNull;
 
 import hudson.model.Run;
 import net.sf.json.JSONObject;
+import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
 import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
 import org.datadog.jenkins.plugins.datadog.model.GitCommitAction;
 import org.datadog.jenkins.plugins.datadog.model.GitRepositoryAction;
@@ -74,7 +75,7 @@ public abstract class DatadogTraceAbstractTest {
         assertNotNull(nodeName);
         // if nodeName == master, should be null, otherwise should be none
         Object hostTagVal = meta.get(CITags._DD_HOSTNAME);
-        if ("master".equals(nodeName) || "built-in".equals(nodeName)) {
+        if (DatadogUtilities.isMainNode((String)nodeName)) {
             assertNull(hostTagVal);
         } else {
             assertEquals("none", hostTagVal);

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogTraceAbstractTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogTraceAbstractTest.java
@@ -74,7 +74,7 @@ public abstract class DatadogTraceAbstractTest {
         assertNotNull(nodeName);
         // if nodeName == master, should be null, otherwise should be none
         Object hostTagVal = meta.get(CITags._DD_HOSTNAME);
-        if ("master".equals(nodeName)) {
+        if ("master".equals(nodeName) || "built-in".equals(nodeName)) {
             assertNull(hostTagVal);
         } else {
             assertEquals("none", hostTagVal);


### PR DESCRIPTION
### What does this PR do?

The main worker got renamed from "master" to "built-in" in recent Jenkins versions. Adds support for both names.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

