### PR TITLE
Fix logs not showing in Jenkins when log collection was enabled

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogOutputStream.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogOutputStream.java
@@ -31,36 +31,20 @@ import hudson.console.LineTransformationOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public class DatadogOutputStream extends LineTransformationOutputStream {
-    private OutputStream delegate;
+public class DatadogOutputStream extends LineTransformationOutputStream.Delegating {
     private DatadogWriter writer;
 
-
     public DatadogOutputStream(OutputStream delegate, DatadogWriter writer) {
-        super();
-        this.delegate = delegate;
+        super(delegate);
         this.writer = writer;
     }
 
     @Override
     protected void eol(byte[] b, int len) throws IOException {
-        delegate.write(b, 0, len);
-        this.flush();
-
+        out.write(b, 0, len);
         String line = new String(b, 0, len, writer.getCharset());
         line = ConsoleNote.removeNotes(line).trim();
         writer.write(line);
     }
 
-    @Override
-    public void flush() throws IOException {
-        delegate.flush();
-        super.flush();
-    }
-
-    @Override
-    public void close() throws IOException {
-        delegate.close();
-        super.close();
-    }
 }


### PR DESCRIPTION
### What does this PR do?

Simplifies the `DatadogOutputStream` by extending `LineTransformationOutputStream.Delegating` (which exists for this purpose) instead of the base `LineTransformationOutputStream`.

This fixes the problem where logs for a job would not show up in Jenkins if they were being sent to Datadog.

Fixes #324

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

