### PR TITLE
Fix hostname not being set for worker nodes in freestyle jobs

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -76,6 +76,10 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     public static final String DD_AGENT_PORT = "DD_AGENT_PORT";
     public static final String DD_TRACE_AGENT_PORT = "DD_TRACE_AGENT_PORT";
     public static final String DD_TRACE_AGENT_URL = "DD_TRACE_AGENT_URL";
+
+    // Env Var key to get the hostname from the Jenkins workers.
+    public static final String DD_CI_HOSTNAME = "DD_CI_HOSTNAME";
+
     // Jenkins Agent EnvVars
     public static final String TARGET_HOST_PROPERTY = "DATADOG_JENKINS_PLUGIN_TARGET_HOST";
     public static final String TARGET_PORT_PROPERTY = "DATADOG_JENKINS_PLUGIN_TARGET_PORT";

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -35,8 +35,10 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.User;
 import hudson.model.labels.LabelAtom;
+import hudson.util.LogTaskListener;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
 import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
 import org.datadog.jenkins.plugins.datadog.model.GitCommitAction;
 import org.datadog.jenkins.plugins.datadog.model.GitRepositoryAction;
@@ -87,8 +89,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -550,6 +554,24 @@ public class DatadogUtilities {
         }
 
         return null;
+    }
+
+    /**
+     * Fetches the environment variables from the worker and returns the value
+     * of DD_CI_HOSTNAME if set.
+     *
+     * @param run  - Current build
+     * @return the specified hostname or an empty Optional if not set
+     */
+    public static Optional<String> getHostnameFromWorkerEnv(Run run) {
+        try {
+            Map<String, String> env = run.getEnvironment(new LogTaskListener(logger, Level.INFO));
+            String envHostname = env.get(DatadogGlobalConfiguration.DD_CI_HOSTNAME);
+            if (StringUtils.isNotEmpty(envHostname)) {
+                return Optional.of(envHostname);
+            }
+        } catch (IOException | InterruptedException e) { }
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/StepData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/StepData.java
@@ -19,7 +19,7 @@ public class StepData implements Serializable {
     private static final long serialVersionUID = 1L;
 
     // Env Var key to get the hostname from the Jenkins workers.
-    private static final String DD_CI_HOSTNAME = "DD_CI_HOSTNAME";
+    public static final String DD_CI_HOSTNAME = "DD_CI_HOSTNAME";
 
     private static transient final Logger logger = Logger.getLogger(StepData.class.getName());
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/StepData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/StepData.java
@@ -3,6 +3,7 @@ package org.datadog.jenkins.plugins.datadog.model;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.Computer;
+import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration;
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
 import org.datadog.jenkins.plugins.datadog.audit.DatadogAudit;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -17,9 +18,6 @@ import java.util.stream.Collectors;
 public class StepData implements Serializable {
 
     private static final long serialVersionUID = 1L;
-
-    // Env Var key to get the hostname from the Jenkins workers.
-    public static final String DD_CI_HOSTNAME = "DD_CI_HOSTNAME";
 
     private static transient final Logger logger = Logger.getLogger(StepData.class.getName());
 
@@ -90,7 +88,7 @@ public class StepData implements Serializable {
      * @return hostname of the remote node.
      */
     private String getNodeHostname(final StepContext stepContext, Map<String,String> envVars) {
-        String hostname = envVars.get(DD_CI_HOSTNAME);
+        String hostname = envVars.get(DatadogGlobalConfiguration.DD_CI_HOSTNAME);
         if (hostname == null) {
             Computer computer;
             try {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
@@ -8,10 +8,12 @@ import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeB
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeTag;
 import static org.datadog.jenkins.plugins.datadog.util.git.GitUtils.isValidCommit;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
@@ -21,11 +23,13 @@ import org.datadog.jenkins.plugins.datadog.model.BuildPipelineNode;
 import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
 import org.datadog.jenkins.plugins.datadog.model.PipelineQueueInfoAction;
 import org.datadog.jenkins.plugins.datadog.model.StageBreakdownAction;
+import org.datadog.jenkins.plugins.datadog.model.StepData;
 import org.datadog.jenkins.plugins.datadog.traces.message.TraceSpan;
 import org.datadog.jenkins.plugins.datadog.transport.HttpClient;
 
 import hudson.model.Result;
 import hudson.model.Run;
+import hudson.util.LogTaskListener;
 
 /**
  * Keeps the logic to send traces related to Jenkins Build.
@@ -142,10 +146,18 @@ public class DatadogTraceBuildLogic extends DatadogBaseBuildLogic {
         // If the NodeName == "master", we don't set _dd.hostname. It will be overridden by the Datadog Agent. (Traces are only available using Datadog Agent)
         if(!"master".equalsIgnoreCase(nodeName)){
             final String workerHostname = getNodeHostname(run, updatedBuildData);
-            // If the worker hostname is equals to controller hostname but the node name is not "master"
-            // then we could not detect the worker hostname properly. We set _dd.hostname to 'none' explicitly.
+            // If the worker hostname is equals to controller hostname but the node name is not master/built-in then we
+            // could not detect the worker hostname properly. Check if it's set in the environment, otherwise set to none.
             if(buildData.getHostname("").equalsIgnoreCase(workerHostname)) {
-                buildSpan.putMeta(CITags._DD_HOSTNAME, HOSTNAME_NONE);
+                String envHostnameOrNone = HOSTNAME_NONE;
+                try {
+                    Map<String, String> env = run.getEnvironment(new LogTaskListener(logger, Level.INFO));
+                    String envHostname = env.get(StepData.DD_CI_HOSTNAME);
+                    if (StringUtils.isNotEmpty(envHostname)) {
+                        envHostnameOrNone = envHostname;
+                    }
+                } catch (IOException | InterruptedException e) { }
+                buildSpan.putMeta(CITags._DD_HOSTNAME, envHostnameOrNone);
             } else {
                 buildSpan.putMeta(CITags._DD_HOSTNAME, (workerHostname != null) ? workerHostname : HOSTNAME_NONE);
             }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -7,13 +7,11 @@ import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeB
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeTag;
 import static org.datadog.jenkins.plugins.datadog.util.git.GitUtils.isValidCommit;
 
-import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
@@ -24,11 +22,9 @@ import org.datadog.jenkins.plugins.datadog.model.BuildPipelineNode;
 import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
 import org.datadog.jenkins.plugins.datadog.model.PipelineQueueInfoAction;
 import org.datadog.jenkins.plugins.datadog.model.StageBreakdownAction;
-import org.datadog.jenkins.plugins.datadog.model.StepData;
 import org.datadog.jenkins.plugins.datadog.traces.message.TraceSpan;
 
 import hudson.model.Run;
-import hudson.util.LogTaskListener;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
@@ -204,14 +200,7 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
                 // If the worker hostname is equals to controller hostname but the node name is not master/built-in then we
                 // could not detect the worker hostname properly. Check if it's set in the environment, otherwise set to none.
                 if(buildData.getHostname("").equalsIgnoreCase(workerHostname)) {
-                    String envHostnameOrNone = HOSTNAME_NONE;
-                    try {
-                        Map<String, String> env = run.getEnvironment(new LogTaskListener(logger, Level.INFO));
-                        String envHostname = env.get(StepData.DD_CI_HOSTNAME);
-                        if (StringUtils.isNotEmpty(envHostname)) {
-                            envHostnameOrNone = envHostname;
-                        }
-                    } catch (IOException | InterruptedException e) { }
+                    String envHostnameOrNone = DatadogUtilities.getHostnameFromWorkerEnv(run).orElse(HOSTNAME_NONE);
                     nodePayload.put("hostname", envHostnameOrNone);
                 } else {
                     nodePayload.put("hostname", (workerHostname != null) ? workerHostname : HOSTNAME_NONE);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -7,11 +7,13 @@ import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeB
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeTag;
 import static org.datadog.jenkins.plugins.datadog.util.git.GitUtils.isValidCommit;
 
+import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
@@ -22,10 +24,11 @@ import org.datadog.jenkins.plugins.datadog.model.BuildPipelineNode;
 import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
 import org.datadog.jenkins.plugins.datadog.model.PipelineQueueInfoAction;
 import org.datadog.jenkins.plugins.datadog.model.StageBreakdownAction;
+import org.datadog.jenkins.plugins.datadog.model.StepData;
 import org.datadog.jenkins.plugins.datadog.traces.message.TraceSpan;
-import org.datadog.jenkins.plugins.datadog.util.git.GitUtils;
 
 import hudson.model.Run;
+import hudson.util.LogTaskListener;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
@@ -197,10 +200,19 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
 
             if(!"master".equalsIgnoreCase(nodeName)){
                 final String workerHostname = getNodeHostname(run, updatedBuildData);
-                // If the worker hostname is equals to controller hostname but the node name is not "master"
-                // then we could not detect the worker hostname properly. We set _dd.hostname to 'none' explicitly.
+
+                // If the worker hostname is equals to controller hostname but the node name is not master/built-in then we
+                // could not detect the worker hostname properly. Check if it's set in the environment, otherwise set to none.
                 if(buildData.getHostname("").equalsIgnoreCase(workerHostname)) {
-                    nodePayload.put("hostname", HOSTNAME_NONE);
+                    String envHostnameOrNone = HOSTNAME_NONE;
+                    try {
+                        Map<String, String> env = run.getEnvironment(new LogTaskListener(logger, Level.INFO));
+                        String envHostname = env.get(StepData.DD_CI_HOSTNAME);
+                        if (StringUtils.isNotEmpty(envHostname)) {
+                            envHostnameOrNone = envHostname;
+                        }
+                    } catch (IOException | InterruptedException e) { }
+                    nodePayload.put("hostname", envHostnameOrNone);
                 } else {
                     nodePayload.put("hostname", (workerHostname != null) ? workerHostname : HOSTNAME_NONE);
                 }


### PR DESCRIPTION
### What does this PR do?

Try to read hostname from the environment if not in `updatedBuildData`.

If a job has no child stages (eg: in a freestyle job), `updatedBuildData` in `DatadogWebhookBuildLogic` will never actually be updated because `DatadogWebhookPipelineLogic` didn't run. Because of this even if the job runs in a worker node everything we read from `updatedBuildData` will be the main node's info. 

When this happens, this PR adds a workaround to read the hostname from the `DD_CI_HOSTNAME` env var directly from `DatadogWebhookBuildLogic`.

### Alternate Designs

Ideally we should have a single way to get the workers info that works both for pipelines and for single jobs. But the logic is too convoluted and I'm not confident enough to do a bigger change.

### Verification Process

Run a freestyle job on a worker with the `DD_CI_HOSTNAME` variable set, check that the host is set properly in the payloads.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

