### PR TITLE
Webhooks: Move user and parameters to the top level

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -132,6 +132,25 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
         payload.put("unique_id", buildData.getBuildTag(""));
         payload.put("name", buildData.getBaseJobName(""));
 
+        // User
+        {
+            JSONObject userPayload = new JSONObject();
+            userPayload.put("name", buildData.getUserId());
+            if(StringUtils.isNotEmpty(buildData.getUserEmail(""))){
+                userPayload.put("email", buildData.getUserEmail(""));
+            }
+            payload.put("user", userPayload);
+        }
+
+        // Pipeline Parameters
+        if (!buildData.getBuildParameters().isEmpty()) {
+            JSONObject parametersPayload = new JSONObject();
+            for (Map.Entry<String, String> parameter : buildData.getBuildParameters().entrySet()) {
+                parametersPayload.put(parameter.getKey(), parameter.getValue());
+            }
+            payload.put("parameters", parametersPayload);
+        }
+
         // Tags
         // Here we include both global tags and fields that are not supported as regular fields by the webhooks intake
         {
@@ -156,17 +175,6 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
 
             // For backwards compat
             tagsPayload.add(prefix + CITags._RESULT + ":" + status);
-
-            // User
-            tagsPayload.add(CITags.USER_NAME + ":" + buildData.getUserId());
-            if(StringUtils.isNotEmpty(buildData.getUserEmail(""))){
-                tagsPayload.add(CITags.USER_EMAIL + ":" + buildData.getUserEmail(""));
-            }
-
-            // Pipeline Parameters
-            if(!buildData.getBuildParameters().isEmpty()) {
-                tagsPayload.add(CITags.CI_PARAMETERS + ":" + toJson(buildData.getBuildParameters()));
-            }
 
             // Configurations
             final String fullJobName = buildData.getJobName("");


### PR DESCRIPTION
### Description of the Change

Those are now standard fields supported by the intake, so we no longer need to send them as generic tags.

It also sets the user email in one of the two cases where before we were only setting the user name. This might be because we never have the email from that function, but it shouldn't hurt to try to get it.

### Additional Notes

Doesn't really change the behavior.
