### PR TITLE
Do not map "unstable" status to "success"

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -797,7 +797,7 @@ public class DatadogUtilities {
      * @return the normalized result for the traces based on the jenkins result
      */
     public static String statusFromResult(String result) {
-        String resultLowercase = result == null ? "" : result.toLowerCase();
+        String resultLowercase = result == null ? "error" : result.toLowerCase();
         switch (resultLowercase) {
             case "failure":
                 return "error";

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -792,41 +792,21 @@ public class DatadogUtilities {
     }
 
     /**
-     * Returns a normalize result for traces.
-     * @param result (success, failure, error, aborted, not_build, canceled, skipped, unknown)
-     * @return the normalized result for the traces based on the jenkins result
-     */
-    public static String getNormalizedResultForTraces(@Nonnull String result) {
-        switch (result.toLowerCase()){
-            case "failure":
-                return "error";
-            case "aborted":
-            case "not_built":
-                return "canceled";
-            default:
-                return result.toLowerCase();
-        }
-    }
-
-    /**
      * Returns a normalized result for traces.
-     * NOTE: This is very similar to the above "getNormalizedResultForTraces", but with the difference
-     * that this will not return "unstable", which isn't a valid status on the Webhooks API.
      * @param result (success, failure, error, aborted, not_build, canceled, skipped, unknown)
      * @return the normalized result for the traces based on the jenkins result
      */
-    public static String statusFromResult(@Nonnull String result) {
-        switch (result.toLowerCase()){
+    public static String statusFromResult(String result) {
+        String resultLowercase = result == null ? "" : result.toLowerCase();
+        switch (resultLowercase) {
             case "failure":
                 return "error";
             case "aborted":
                 return "canceled";
             case "not_built":
                 return "skipped";
-            case "unstable": // has non-fatal errors
-                return "success";
             default:
-                return result.toLowerCase();
+                return resultLowercase;
         }
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -130,8 +130,6 @@ public class BuildData implements Serializable {
     private Long startTime;
     private Long endTime;
     private Long duration;
-    private Long secondsInQueue;
-    private Long propagatedSecondsInQueue;
     private Long millisInQueue;
     private Long propagatedMillisInQueue;
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
@@ -1,6 +1,6 @@
 package org.datadog.jenkins.plugins.datadog.traces;
 
-import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.getNormalizedResultForTraces;
+import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.statusFromResult;
 import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.toJson;
 import static org.datadog.jenkins.plugins.datadog.traces.CITags.Values.ORIGIN_CIAPP_PIPELINE;
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.filterSensitiveInfo;
@@ -246,7 +246,7 @@ public class DatadogTraceBuildLogic extends DatadogBaseBuildLogic {
         buildSpan.putMeta(CITags.JENKINS_EXECUTOR_NUMBER, buildData.getExecutorNumber(""));
 
         final String jenkinsResult = buildData.getResult("");
-        final String pipelineResult = getNormalizedResultForTraces(jenkinsResult);
+        final String pipelineResult = statusFromResult(jenkinsResult);
         buildSpan.putMeta(prefix + CITags._RESULT, pipelineResult);
         buildSpan.putMeta(CITags.STATUS, pipelineResult);
         buildSpan.putMeta(CITags.JENKINS_RESULT, jenkinsResult.toLowerCase());

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
@@ -1,7 +1,7 @@
 package org.datadog.jenkins.plugins.datadog.traces;
 
 import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.cleanUpTraceActions;
-import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.getNormalizedResultForTraces;
+import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.statusFromResult;
 import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.toJson;
 import static org.datadog.jenkins.plugins.datadog.model.BuildPipelineNode.NodeType.PIPELINE;
 import static org.datadog.jenkins.plugins.datadog.traces.CITags.Values.ORIGIN_CIAPP_PIPELINE;
@@ -20,12 +20,9 @@ import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
-import org.datadog.jenkins.plugins.datadog.audit.DatadogAudit;
 import org.datadog.jenkins.plugins.datadog.model.BuildData;
 import org.datadog.jenkins.plugins.datadog.model.BuildPipelineNode;
 import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
-import org.datadog.jenkins.plugins.datadog.model.StageBreakdownAction;
-import org.datadog.jenkins.plugins.datadog.model.StageData;
 import org.datadog.jenkins.plugins.datadog.traces.message.TraceSpan;
 import org.datadog.jenkins.plugins.datadog.transport.HttpClient;
 import org.datadog.jenkins.plugins.datadog.transport.PayloadMessage;
@@ -169,7 +166,7 @@ public class DatadogTracePipelineLogic extends DatadogBasePipelineLogic {
         tags.put(CITags._DD_ORIGIN, ORIGIN_CIAPP_PIPELINE);
         tags.put(prefix + CITags._NAME, current.getName());
         tags.put(prefix + CITags._NUMBER, current.getId());
-        final String status = getNormalizedResultForTraces(getResult(current));
+        final String status = statusFromResult(getResult(current));
         tags.put(prefix + CITags._RESULT, status);
         tags.put(CITags.STATUS, status);
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -1,7 +1,6 @@
 package org.datadog.jenkins.plugins.datadog.traces;
 
 import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.statusFromResult;
-import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.toJson;
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.filterSensitiveInfo;
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeBranch;
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeTag;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
@@ -2,7 +2,6 @@ package org.datadog.jenkins.plugins.datadog.traces;
 
 import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.cleanUpTraceActions;
 import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.statusFromResult;
-import static org.datadog.jenkins.plugins.datadog.DatadogUtilities.toJson;
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.filterSensitiveInfo;
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeBranch;
 import static org.datadog.jenkins.plugins.datadog.traces.GitInfoUtils.normalizeTag;


### PR DESCRIPTION
### What does this PR do?

When the result of a job, stage or pipeline is `unstable`, do not map it to `success` when sending webhooks. The webhooks intake now accepts `unstable` as a status. This lets us remove the two different mappings (jenkins result -> ci visibility status) we had depending on whether we send webhooks or traces.

It also removes some unused variables and imports, sorry if it adds a bit of noise to the PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

