### PR TITLE
Remove separate propagated* fields

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipeline.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipeline.java
@@ -135,15 +135,15 @@ public class BuildPipeline {
             if(BuildPipelineNode.NodeType.STAGE.equals(node.getType())) {
                 final BuildPipelineNode executableChildNode = searchExecutableChildNode(node);
                 if(executableChildNode != null) {
-                    node.setPropagatedNodeName(executableChildNode.getNodeName());
-                    node.setPropagatedNodeLabels(executableChildNode.getNodeLabels());
-                    node.setPropagatedNodeHostname(executableChildNode.getNodeHostname());
+                    node.setNodeName(executableChildNode.getNodeName());
+                    node.setNodeLabels(executableChildNode.getNodeLabels());
+                    node.setNodeHostname(executableChildNode.getNodeHostname());
                 }
             }
 
             // Propagate error to all parent stages
             if(node.isError() && !parent.isError()) {
-                propagateErrorToAllParents(node);
+                propagateResultToAllParents(node, "error");
             }
 
             // Notice we cannot propagate the worker node info
@@ -156,12 +156,11 @@ public class BuildPipeline {
         }
     }
 
-    private void propagateErrorToAllParents(BuildPipelineNode node) {
+    private void propagateResultToAllParents(BuildPipelineNode node, String result) {
         for(BuildPipelineNode parent : node.getParents()) {
-            propagateErrorToAllParents(parent);
+            propagateResultToAllParents(parent, result);
         }
-        node.setError(true);
-        node.setPropagatedResult("error");
+        node.setResult(result);
     }
 
     private BuildPipelineNode searchExecutableChildNode(BuildPipelineNode node) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
@@ -72,10 +72,7 @@ public class BuildPipelineNode {
     private String workspace;
     private String nodeName;
     private Set<String> nodeLabels;
-    private String propagatedNodeName;
-    private Set<String> propagatedNodeLabels;
     private String nodeHostname;
-    private String propagatedNodeHostname;
     private long startTime;
     private long startTimeMicros;
     private long endTime;
@@ -83,7 +80,6 @@ public class BuildPipelineNode {
     private long nanosInQueue = -1L;
     private long propagatedNanosInQueue = -1L;
     private String result;
-    private String propagatedResult;
 
     // Flag that indicates if the node must be marked as error.
     private boolean error;
@@ -156,9 +152,6 @@ public class BuildPipelineNode {
         this.endTimeMicros = this.endTime * 1000;
         this.result = DatadogUtilities.getResultTag(startNode);
         this.errorObj = getErrorObj(endNode);
-        if("error".equalsIgnoreCase(this.result)){
-            this.error = true;
-        }
     }
 
     public BuildPipelineNode(final StepAtomNode stepNode) {
@@ -196,9 +189,6 @@ public class BuildPipelineNode {
         this.endTimeMicros = this.endTime * 1000;
         this.result = DatadogUtilities.getResultTag(stepNode);
         this.errorObj = getErrorObj(stepNode);
-        if("error".equalsIgnoreCase(this.result)){
-            this.error = true;
-        }
     }
 
 
@@ -258,32 +248,20 @@ public class BuildPipelineNode {
         return nodeLabels;
     }
 
-    public String getPropagatedNodeName() {
-        return propagatedNodeName;
+    public void setNodeName(String propagatedNodeName) {
+        this.nodeName = propagatedNodeName;
     }
 
-    public void setPropagatedNodeName(String propagatedNodeName) {
-        this.propagatedNodeName = propagatedNodeName;
-    }
-
-    public Set<String> getPropagatedNodeLabels() {
-        return propagatedNodeLabels;
-    }
-
-    public void setPropagatedNodeLabels(final Set<String> propagatedNodeLabels) {
-        this.propagatedNodeLabels = propagatedNodeLabels;
+    public void setNodeLabels(final Set<String> propagatedNodeLabels) {
+        this.nodeLabels = propagatedNodeLabels;
     }
 
     public String getNodeHostname() {
         return nodeHostname;
     }
 
-    public String getPropagatedNodeHostname(){
-        return propagatedNodeHostname;
-    }
-
-    public void setPropagatedNodeHostname(final String propagatedNodeHostname) {
-        this.propagatedNodeHostname = propagatedNodeHostname;
+    public void setNodeHostname(final String propagatedNodeHostname) {
+        this.nodeHostname = propagatedNodeHostname;
     }
 
     public long getStartTime() {
@@ -327,12 +305,8 @@ public class BuildPipelineNode {
         return result;
     }
 
-    public String getPropagatedResult() {
-        return this.propagatedResult;
-    }
-
-    public void setPropagatedResult(final String propagatedResult) {
-        this.propagatedResult = propagatedResult;
+    public void setResult(final String propagatedResult) {
+        this.result = propagatedResult;
     }
 
     public Throwable getErrorObj() {
@@ -340,11 +314,7 @@ public class BuildPipelineNode {
     }
 
     public boolean isError() {
-        return error;
-    }
-
-    public void setError(boolean error) {
-        this.error = error;
+        return "error".equalsIgnoreCase(this.result);
     }
 
     public long getSpanId() {
@@ -444,7 +414,6 @@ public class BuildPipelineNode {
         }
         return null;
     }
-
 
     /**
      * Returns the {@code Throwable} of a certain {@code FlowNode}, if it has errors.

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBasePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBasePipelineLogic.java
@@ -221,9 +221,7 @@ public abstract class DatadogBasePipelineLogic {
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     protected Set<String> getNodeLabels(Run run, BuildPipelineNode current, String nodeName) {
         final PipelineNodeInfoAction pipelineNodeInfoAction = run.getAction(PipelineNodeInfoAction.class);
-        if (current.getPropagatedNodeLabels() != null && !current.getPropagatedNodeLabels().isEmpty()) {
-            return current.getPropagatedNodeLabels();
-        } else if (current.getNodeLabels() != null && !current.getNodeLabels().isEmpty()) {
+        if (current.getNodeLabels() != null && !current.getNodeLabels().isEmpty()) {
             return current.getNodeLabels();
         } else if (pipelineNodeInfoAction != null && !pipelineNodeInfoAction.getNodeLabels().isEmpty()) {
             return pipelineNodeInfoAction.getNodeLabels();
@@ -247,16 +245,10 @@ public abstract class DatadogBasePipelineLogic {
         return Collections.emptySet();
     }
 
-    protected String getResult(BuildPipelineNode current) {
-        return (current.getPropagatedResult() != null) ? current.getPropagatedResult() : current.getResult();
-    }
-
     protected String getNodeName(Run<?, ?> run, BuildPipelineNode current, BuildData buildData) {
         final PipelineNodeInfoAction pipelineNodeInfoAction = run.getAction(PipelineNodeInfoAction.class);
 
-        if(current.getPropagatedNodeName() != null) {
-            return current.getPropagatedNodeName();
-        } else if(current.getNodeName() != null) {
+        if(current.getNodeName() != null) {
             return current.getNodeName();
         } else if (pipelineNodeInfoAction != null) {
             return pipelineNodeInfoAction.getNodeName();
@@ -267,9 +259,7 @@ public abstract class DatadogBasePipelineLogic {
 
     protected String getNodeHostname(Run<?, ?> run, BuildPipelineNode current) {
         final PipelineNodeInfoAction pipelineNodeInfoAction = run.getAction(PipelineNodeInfoAction.class);
-        if(current.getPropagatedNodeHostname() != null) {
-            return current.getPropagatedNodeHostname();
-        } else if(current.getNodeHostname() != null) {
+        if(current.getNodeHostname() != null) {
             return current.getNodeHostname();
         } else if (pipelineNodeInfoAction != null) {
             return pipelineNodeInfoAction.getNodeHostname();

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
@@ -166,7 +166,7 @@ public class DatadogTracePipelineLogic extends DatadogBasePipelineLogic {
         tags.put(CITags._DD_ORIGIN, ORIGIN_CIAPP_PIPELINE);
         tags.put(prefix + CITags._NAME, current.getName());
         tags.put(prefix + CITags._NUMBER, current.getId());
-        final String status = statusFromResult(getResult(current));
+        final String status = statusFromResult(current.getResult());
         tags.put(prefix + CITags._RESULT, status);
         tags.put(CITags.STATUS, status);
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
@@ -88,7 +88,7 @@ public class DatadogWebhookPipelineLogic extends DatadogBasePipelineLogic {
         final long propagatedMillisInQueue = Math.max(buildData.getPropagatedMillisInQueue(-1L), 0);
         final long fixedStartTimeMillis = TimeUnit.MICROSECONDS.toMillis(current.getStartTimeMicros() - TimeUnit.MILLISECONDS.toMicros(propagatedMillisInQueue));
         final long fixedEndTimeMillis = TimeUnit.MICROSECONDS.toMillis(current.getEndTimeMicros() - TimeUnit.MILLISECONDS.toMicros(propagatedMillisInQueue));
-        final String jenkinsResult = getResult(current);
+        final String jenkinsResult = current.getResult();
         final String status = statusFromResult(jenkinsResult);
         final String prefix = current.getType().getTagName();
         final String buildLevel = current.getType().getBuildLevel();


### PR DESCRIPTION
### What does this PR do?

Simplifies the code by removing the `propagated*` fields from `BuildPipelineNode`. Since we were always reading them first instead of the non-propagated ones, we can simply overwrite the existing non-propagated fields.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

