### PR TITLE
Improve comments

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
@@ -29,6 +29,7 @@ import hudson.model.Run;
 
 /**
  * Keeps the logic to send traces related to Jenkins Build.
+ * This gets called once per job (datadog level: pipeline)
  */
 public class DatadogTraceBuildLogic extends DatadogBaseBuildLogic {
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
@@ -32,8 +32,10 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 
 import hudson.model.Run;
 
+
 /**
- * Keeps the logic to send traces related to Jenkins Pipelines.
+ * Keeps the logic to send traces related to inner jobs of Jenkins Pipelines (datadog levels: stage and job).
+ * The top-level job (datadog level: pipeline) is handled by DatadogTraceBuildLogic
  */
 public class DatadogTracePipelineLogic extends DatadogBasePipelineLogic {
 


### PR DESCRIPTION

### What does this PR do?

It's very confused that the logic that sends jobs and stages but not pipelines is called `PipelineLogic` (while the class that sends pipelines is called `BuildLogic`). We should probably rename this class but for now I added a comment.


