### PR TITLE
Add is_manual field to pipelines

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/CITags.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/CITags.java
@@ -9,6 +9,7 @@ public class CITags {
     public static final String ERROR_STACK = "error.stack";
 
     public static final String STATUS = "ci.status";
+    public static final String IS_MANUAL = "ci.is_manual";
     public static final String CI_PARAMETERS = "ci.parameters";
     public static final String WORKSPACE_PATH = "ci.workspace_path";
     public static final String NODE_NAME = "ci.node.name";

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
@@ -15,7 +15,7 @@ import org.datadog.jenkins.plugins.datadog.model.StageBreakdownAction;
 import org.datadog.jenkins.plugins.datadog.model.StageData;
 import org.datadog.jenkins.plugins.datadog.util.SuppressFBWarnings;
 import org.datadog.jenkins.plugins.datadog.util.json.JsonUtils;
-
+import hudson.model.Cause;
 import hudson.model.Run;
 
 /**
@@ -39,7 +39,7 @@ public abstract class DatadogBaseBuildLogic {
         return buildData.getNodeName("").isEmpty() ? updatedBuildData.getNodeName("") : buildData.getNodeName("");
     }
 
-    protected String getNodeHostname(Run<?, ?> run, BuildData updatedBuildData) {
+    static protected String getNodeHostname(Run<?, ?> run, BuildData updatedBuildData) {
         final PipelineNodeInfoAction pipelineNodeInfoAction = run.getAction(PipelineNodeInfoAction.class);
         if(pipelineNodeInfoAction != null){
             return pipelineNodeInfoAction.getNodeHostname();
@@ -50,7 +50,7 @@ public abstract class DatadogBaseBuildLogic {
     }
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
-    protected Set<String> getNodeLabels(Run<?,?> run, final String nodeName) {
+    static protected Set<String> getNodeLabels(Run<?,?> run, final String nodeName) {
         try {
             if(run == null){
                 return Collections.emptySet();
@@ -83,7 +83,7 @@ public abstract class DatadogBaseBuildLogic {
         }
     }
 
-    protected long getMillisInQueue(BuildData buildData) {
+    static protected long getMillisInQueue(BuildData buildData) {
         // Reported by the Jenkins Queue API.
         // It's not included in the root span duration.
         final long millisInQueue = buildData.getMillisInQueue(-1L);
@@ -94,7 +94,7 @@ public abstract class DatadogBaseBuildLogic {
         return Math.max(Math.max(millisInQueue, propagatedMillisInQueue), 0);
     }
 
-    protected String getStageBreakdown(Run run) {
+    static protected String getStageBreakdown(Run run) {
         final StageBreakdownAction stageBreakdownAction = run.getAction(StageBreakdownAction.class);
         if(stageBreakdownAction == null) {
             return null;
@@ -111,6 +111,17 @@ public abstract class DatadogBaseBuildLogic {
         }
 
         return stagesJson;
+    }
+
+    // Returns true if the run causes contains a Cause.UserIdCause
+    static public boolean isTriggeredManually(Run run) {
+        final List<Cause> causes = run.getCauses();
+        for (Cause cause : causes) {
+            if (cause instanceof Cause.UserIdCause) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
@@ -39,7 +39,7 @@ public abstract class DatadogBaseBuildLogic {
         return buildData.getNodeName("").isEmpty() ? updatedBuildData.getNodeName("") : buildData.getNodeName("");
     }
 
-    static protected String getNodeHostname(Run<?, ?> run, BuildData updatedBuildData) {
+    protected String getNodeHostname(Run<?, ?> run, BuildData updatedBuildData) {
         final PipelineNodeInfoAction pipelineNodeInfoAction = run.getAction(PipelineNodeInfoAction.class);
         if(pipelineNodeInfoAction != null){
             return pipelineNodeInfoAction.getNodeHostname();
@@ -50,7 +50,7 @@ public abstract class DatadogBaseBuildLogic {
     }
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
-    static protected Set<String> getNodeLabels(Run<?,?> run, final String nodeName) {
+    protected Set<String> getNodeLabels(Run<?,?> run, final String nodeName) {
         try {
             if(run == null){
                 return Collections.emptySet();
@@ -83,7 +83,7 @@ public abstract class DatadogBaseBuildLogic {
         }
     }
 
-    static protected long getMillisInQueue(BuildData buildData) {
+    protected long getMillisInQueue(BuildData buildData) {
         // Reported by the Jenkins Queue API.
         // It's not included in the root span duration.
         final long millisInQueue = buildData.getMillisInQueue(-1L);
@@ -94,7 +94,7 @@ public abstract class DatadogBaseBuildLogic {
         return Math.max(Math.max(millisInQueue, propagatedMillisInQueue), 0);
     }
 
-    static protected String getStageBreakdown(Run run) {
+    protected String getStageBreakdown(Run run) {
         final StageBreakdownAction stageBreakdownAction = run.getAction(StageBreakdownAction.class);
         if(stageBreakdownAction == null) {
             return null;
@@ -114,7 +114,7 @@ public abstract class DatadogBaseBuildLogic {
     }
 
     // Returns true if the run causes contains a Cause.UserIdCause
-    static public boolean isTriggeredManually(Run run) {
+    public boolean isTriggeredManually(Run run) {
         final List<Cause> causes = run.getCauses();
         for (Cause cause : causes) {
             if (cause instanceof Cause.UserIdCause) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTraceBuildLogic.java
@@ -113,6 +113,7 @@ public class DatadogTraceBuildLogic extends DatadogBaseBuildLogic {
         buildSpan.putMeta(CITags._DD_CI_INTERNAL, "false");
         buildSpan.putMeta(CITags._DD_CI_BUILD_LEVEL, buildLevel);
         buildSpan.putMeta(CITags._DD_CI_LEVEL, buildLevel);
+        buildSpan.putMeta(CITags.IS_MANUAL, isTriggeredManually(run));
         buildSpan.putMeta(CITags._DD_ORIGIN, ORIGIN_CIAPP_PIPELINE);
         buildSpan.putMeta(CITags.USER_NAME, buildData.getUserId());
         if(StringUtils.isNotEmpty(buildData.getUserEmail(""))){

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -123,6 +123,7 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
         payload.put("partial_retry", false);
         payload.put("queue_time", getMillisInQueue(updatedBuildData));
         payload.put("status", status);
+        payload.put("is_manual", isTriggeredManually(run));
 
         payload.put("trace_id", buildSpan.context().getTraceId());
         payload.put("span_id", buildSpan.context().getSpanId());


### PR DESCRIPTION
### What does this PR do?

Adds the `is_manual` field that is true when a `Run` contains a `UserIdCause`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

