### PR TITLE
chore: don't redirect to a closed INFRA Jira issue for the "Datadog" Jira search URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Checkout the [development document][12] for tips on spinning up a quick developm
 [6]: https://wiki.jenkins-ci.org/display/JENKINS/Logging
 [7]: https://github.com/jenkinsci/datadog-plugin/issues
 [8]: https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20status%20in%20%28Open%2C%20%22In%20Progress%22%2C%20Reopened%29%20AND%20component%20%3D%20datadog-plugin%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC
-[9]: https://issues.jenkins-ci.org/browse/INFRA-305?jql=status%20in%20%28Open%2C%20%22In%20Progress%22%2C%20Reopened%2C%20Verified%2C%20Untriaged%2C%20%22Fix%20Prepared%22%29%20AND%20text%20~%20%22datadog%22
+[9]: https://issues.jenkins-ci.org/issues/?jql=status%20in%20%28Open%2C%20%22In%20Progress%22%2C%20Reopened%2C%20Verified%2C%20Untriaged%2C%20%22Fix%20Prepared%22%29%20AND%20text%20~%20%22datadog%22
 [10]: https://github.com/jenkinsci/datadog-plugin/blob/master/CHANGELOG.md
 [11]: https://github.com/jenkinsci/datadog-plugin/blob/master/CONTRIBUTING.md
 [12]: https://github.com/jenkinsci/datadog-plugin/blob/master/DEVELOPMENT.md


### PR DESCRIPTION
### What does this PR do?

This PR update the "datadog" Jira search link so it doesn't redirect to a closed INFRA Jira issue.

### Description of the Change

Removed the INFRA Jira id from the URL.

### Alternate Designs

N/A

### Possible Drawbacks

None

### Verification Process

Opened the link in a new tab.

### Additional Notes

N/A

### Release Notes

This doesn't worth a release note.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

