### PR TITLE
Fix error status propagation to take into account catch/catchError/warnError blocks

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -47,12 +47,14 @@ import org.datadog.jenkins.plugins.datadog.model.PipelineQueueInfoAction;
 import org.datadog.jenkins.plugins.datadog.model.StageBreakdownAction;
 import org.datadog.jenkins.plugins.datadog.steps.DatadogPipelineAction;
 import org.datadog.jenkins.plugins.datadog.traces.BuildSpanAction;
+import org.datadog.jenkins.plugins.datadog.traces.CITags;
 import org.datadog.jenkins.plugins.datadog.traces.IsPipelineAction;
 import org.datadog.jenkins.plugins.datadog.traces.StepDataAction;
 import org.datadog.jenkins.plugins.datadog.traces.StepTraceDataAction;
 import org.datadog.jenkins.plugins.datadog.util.SuppressFBWarnings;
 import org.datadog.jenkins.plugins.datadog.util.TagsUtil;
 import org.jenkinsci.plugins.pipeline.StageStatus;
+import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.NotExecutedNodeAction;
@@ -981,5 +983,23 @@ public class DatadogUtilities {
      */
     public static URL buildHttpURL(final String hostname, final Integer port, final String path) throws MalformedURLException {
         return new URL(String.format("http://%s:%d"+path, hostname, port));
+    }
+
+    public static String getCatchErrorResult(BlockStartNode startNode) {
+        String displayFunctionName = startNode.getDisplayFunctionName();
+        if ("warnError".equals(displayFunctionName)) {
+            return CITags.STATUS_UNSTABLE;
+        }
+        if ("catchError".equals(displayFunctionName)) {
+            ArgumentsAction argumentsAction = startNode.getAction(ArgumentsAction.class);
+            if (argumentsAction != null) {
+                Map<String, Object> arguments = argumentsAction.getArguments();
+                Object stageResult = arguments.get("stageResult");
+                return stageResult != null
+                        ? statusFromResult(stageResult.toString())
+                        : CITags.STATUS_SUCCESS;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildPipelineNode.java
@@ -83,8 +83,8 @@ public class BuildPipelineNode {
     private long propagatedNanosInQueue = -1L;
     private String result;
 
-    // Flag that indicates if the node must be marked as error.
-    private boolean error;
+    // If the node is a `catchError` block, this field will contain the `stageResult` parameter
+    private String catchErrorResult;
     // Throwable of the node.
     // Although the error flag was true, this can be null.
     private Throwable errorObj;
@@ -131,6 +131,7 @@ public class BuildPipelineNode {
             this.internal = true;
         }
 
+        this.catchErrorResult = DatadogUtilities.getCatchErrorResult(startNode);
         this.args = ArgumentsAction.getFilteredArguments(startNode);
 
         if(endNode instanceof StepNode){
@@ -358,6 +359,10 @@ public class BuildPipelineNode {
         return type;
     }
 
+    public String getCatchErrorResult() {
+        return catchErrorResult;
+    }
+
     // Used during the tree is being built in BuildPipeline class.
     public void updateData(final BuildPipelineNode buildNode) {
         this.stageName = buildNode.stageName;
@@ -377,7 +382,7 @@ public class BuildPipelineNode {
         this.endTimeMicros = buildNode.endTimeMicros;
         this.nanosInQueue = buildNode.nanosInQueue;
         this.result = buildNode.result;
-        this.error = buildNode.error;
+        this.catchErrorResult = buildNode.catchErrorResult;
         this.errorObj = buildNode.errorObj;
         this.unstableMessage = buildNode.unstableMessage;
         this.parents.addAll(buildNode.parents);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/CITags.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/CITags.java
@@ -55,6 +55,7 @@ public class CITags {
     public static final String JENKINS_EXECUTOR_NUMBER = "jenkins.executor.number";
     public static final String JENKINS_RESULT = "jenkins.result";
 
+    public static final String STATUS_SUCCESS = "success";
     public static final String STATUS_ERROR = "error";
     public static final String STATUS_UNSTABLE = "unstable";
 

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
@@ -1213,7 +1213,7 @@ public class DatadogGraphListenerTest extends DatadogTraceAbstractTest {
         final TraceSpan stepSpan = spans.get(2);
         assertEquals(true, stepSpan.isError());
         assertEquals(CITags.STATUS_ERROR, stepSpan.getMeta().get(CITags.STATUS));
-        assertEquals("hudson.AbortException", stepSpan.getMeta().get(CITags.ERROR_TYPE));
+        assertEquals(stepSpan.getMeta().get("error.stack"), "hudson.AbortException", stepSpan.getMeta().get(CITags.ERROR_TYPE));
 
         final TraceSpan stageSpan = spans.get(1);
         assertEquals(true, stageSpan.isError());

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
@@ -65,7 +65,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -1199,7 +1198,7 @@ public class DatadogGraphListenerTest extends DatadogTraceAbstractTest {
     public void testErrorPropagationOnStages() throws Exception {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "pipelineIntegration-errorPropagationStages");
         String definition = IOUtils.toString(
-                this.getClass().getResourceAsStream("testPipelineErrorOnStages.txt"),
+                this.getClass().getResourceAsStream(getFailingPipelineDefinitionName()),
                 "UTF-8"
         );
         job.setDefinition(new CpsFlowDefinition(definition, true));
@@ -1230,7 +1229,7 @@ public class DatadogGraphListenerTest extends DatadogTraceAbstractTest {
 
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "pipelineIntegration-errorPropagationStagesWebhook");
         String definition = IOUtils.toString(
-                this.getClass().getResourceAsStream("testPipelineErrorOnStages.txt"),
+                this.getClass().getResourceAsStream(getFailingPipelineDefinitionName()),
                 "UTF-8"
         );
         job.setDefinition(new CpsFlowDefinition(definition, true));
@@ -1250,6 +1249,16 @@ public class DatadogGraphListenerTest extends DatadogTraceAbstractTest {
 
         final JSONObject pipeline = searchWebhookByLevel(webhooks, "pipeline");
         assertEquals(CITags.STATUS_ERROR, pipeline.getString("status"));
+    }
+
+    // need to use a different pipeline on Windows, since "sh" command is not supported there,
+    // and when trying to run a shell script the error is different from the one that we're modelling in our tests
+    private String getFailingPipelineDefinitionName() {
+        return isRunningOnWindows() ? "testPipelineErrorOnStagesOnWindows.txt" : "testPipelineErrorOnStages.txt";
+    }
+
+    private boolean isRunningOnWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
     }
 
     @Test

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStages.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStages.txt
@@ -1,0 +1,15 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Outer Stage') {
+            stages {
+                stage('Inner Stage') {
+                    steps {
+                        sh 'exit 1'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesCatchFailureFailure.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesCatchFailureFailure.txt
@@ -1,0 +1,17 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Outer Stage') {
+            stages {
+                stage('Inner Stage') {
+                    steps {
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            sh 'exit 1'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesCatchSuccessFailure.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesCatchSuccessFailure.txt
@@ -1,0 +1,17 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Outer Stage') {
+            stages {
+                stage('Inner Stage') {
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh 'exit 1'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesCatchSuccessSuccess.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesCatchSuccessSuccess.txt
@@ -1,0 +1,17 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Outer Stage') {
+            stages {
+                stage('Inner Stage') {
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
+                            sh 'exit 1'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesCatchSuccessUnstable.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesCatchSuccessUnstable.txt
@@ -1,0 +1,17 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Outer Stage') {
+            stages {
+                stage('Inner Stage') {
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+                            sh 'exit 1'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesCatchUnstableFailure.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesCatchUnstableFailure.txt
@@ -1,0 +1,17 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Outer Stage') {
+            stages {
+                stage('Inner Stage') {
+                    steps {
+                        catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+                            sh 'exit 1'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesScriptedCatchRethrow.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesScriptedCatchRethrow.txt
@@ -1,0 +1,21 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Outer Stage') {
+            stages {
+                stage('Inner Stage') {
+                    steps {
+                        script {
+                            try {
+                                sh 'exit 1'
+                            } catch (Exception e) {
+                                throw e
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesScriptedCatchSuppress.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesScriptedCatchSuppress.txt
@@ -1,0 +1,21 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Outer Stage') {
+            stages {
+                stage('Inner Stage') {
+                    steps {
+                        script {
+                            try {
+                                sh 'exit 1'
+                            } catch (Exception e) {
+                                // suppress error
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesWarnError.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testErrorPropagationOnNestedStagesWarnError.txt
@@ -1,0 +1,17 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Outer Stage') {
+            stages {
+                stage('Inner Stage') {
+                    steps {
+                        warnError(message: 'warning message') {
+                            sh 'exit 1'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineErrorOnStagesOnWindows.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testPipelineErrorOnStagesOnWindows.txt
@@ -1,0 +1,10 @@
+pipeline {
+    agent any
+    stages {
+        stage('test'){
+            steps {
+               bat "this-does-not-exist"
+            }
+        }
+    }
+}

--- a/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testUnstablePropagationOnNestedStages.txt
+++ b/src/test/resources/org/datadog/jenkins/plugins/datadog/listeners/testUnstablePropagationOnNestedStages.txt
@@ -1,0 +1,15 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Outer Stage') {
+            stages {
+                stage('Inner Stage') {
+                    steps {
+                        unstable('this stage is unstable')
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

This PR fixes logic that propagates errors from pipeline nodes to their parents.
The problem is that currently errors are propagated unconditionally from a node to its ancestors until the root node is reached.
This approach is not always correct, as an error in the pipeline might be caught and suppressed, in which case Jenkins can report as successful the stage that caught the error (along with all its parents).
The desired state is to have statuses of the spans sent to Datadog exactly the same as the statuses of corresponding Jenkins pipeline stages, which means the logic should be adjusted to stop propagation if the error was caught.

The motivation to change this now is that there is a customer complaining about the statuses disparity.

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

There are 3 ways to catch and suppress an error:
* `try`/`catch` block in a scripted pipeline
* `catchError` block in a declarative pipeline
* `warnError` block in a declarative pipeline

For the latter two `BuildPipelineNode` class was augmented with an additional field that stores the status that should be applied if an error occurs in that node (with `catchError` this status can be configured, with `warnError` the status is always `unstable`).
For the first one, existing field `BuildPipelineNode#errorObj` is examined: if an error is caught and suppressed, the node that caught it will have `null` in that field.

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Verified manually with a local Jenkins instance and DD staging, and covered with integration tests that contain examples of pipelines where errors are caught using different ways.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

