### PR TITLE
Add option to use AWS instance ID as hostname

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -1279,7 +1279,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     /**
      * @return - A {@link Boolean} indicating if the user has configured Datadog to use AWS instance as hostname
      */
-    public boolean doUseAwsInstanceHostname() {
+    public boolean isUseAwsInstanceHostname() {
         return useAwsInstanceHostname;
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -109,6 +109,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private static final String RETRY_LOGS_PROPERTY = "DATADOG_JENKINS_PLUGIN_RETRY_LOGS";
     private static final String REFRESH_DOGSTATSD_CLIENT_PROPERTY = "DATADOG_REFRESH_STATSD_CLIENT";
     private static final String CACHE_BUILD_RUNS_PROPERTY = "DATADOG_CACHE_BUILD_RUNS";
+    private static final String USE_AWS_INSTANCE_HOSTNAME_PROPERTY = "DATADOG_USE_AWS_INSTANCE_HOSTNAME";
 
     private static final String ENABLE_CI_VISIBILITY_PROPERTY = "DATADOG_JENKINS_PLUGIN_ENABLE_CI_VISIBILITY";
     private static final String CI_VISIBILITY_CI_INSTANCE_NAME_PROPERTY = "DATADOG_JENKINS_PLUGIN_CI_VISIBILITY_CI_INSTANCE_NAME";
@@ -130,6 +131,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private static final boolean DEFAULT_RETRY_LOGS_VALUE = true;
     private static final boolean DEFAULT_REFRESH_DOGSTATSD_CLIENT_VALUE = false;
     private static final boolean DEFAULT_CACHE_BUILD_RUNS_VALUE = true;
+    private static final boolean DEFAULT_USE_AWS_INSTANCE_HOSTNAME_VALUE = false;
 
     private String reportWith = DEFAULT_REPORT_WITH_VALUE;
     private String targetApiURL = DEFAULT_TARGET_API_URL_VALUE;
@@ -157,6 +159,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     private boolean retryLogs = DEFAULT_RETRY_LOGS_VALUE;
     private boolean refreshDogstatsdClient = DEFAULT_REFRESH_DOGSTATSD_CLIENT_VALUE;
     private boolean cacheBuildRuns = DEFAULT_CACHE_BUILD_RUNS_VALUE;
+    private boolean useAwsInstanceHostname = DEFAULT_USE_AWS_INSTANCE_HOSTNAME_VALUE;
 
     @DataBoundConstructor
     public DatadogGlobalConfiguration() {
@@ -290,6 +293,11 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
         String cacheBuildRunsEnvVar = System.getenv(CACHE_BUILD_RUNS_PROPERTY);
         if(StringUtils.isNotBlank(cacheBuildRunsEnvVar)){
             this.cacheBuildRuns = Boolean.valueOf(cacheBuildRunsEnvVar);
+        }
+
+        String useAwsInstanceHostnameEnvVar = System.getenv(USE_AWS_INSTANCE_HOSTNAME_PROPERTY);
+        if(StringUtils.isNotBlank(useAwsInstanceHostnameEnvVar)){
+            this.useAwsInstanceHostname = Boolean.valueOf(useAwsInstanceHostnameEnvVar);
         }
 
         String enableCiVisibilityVar = System.getenv(ENABLE_CI_VISIBILITY_PROPERTY);
@@ -746,6 +754,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
             this.setRetryLogs(formData.getBoolean("retryLogs"));
             this.setRefreshDogstatsdClient(formData.getBoolean("refreshDogstatsdClient"));
             this.setCacheBuildRuns(formData.getBoolean("cacheBuildRuns"));
+            this.setUseAwsInstanceHostname(formData.getBoolean("useAwsInstanceHostname"));
             this.setEmitSystemEvents(formData.getBoolean("emitSystemEvents"));
             this.setEmitConfigChangeEvents(formData.getBoolean("emitConfigChangeEvents"));
 
@@ -1265,6 +1274,24 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
     @DataBoundSetter
     public void setCacheBuildRuns(boolean cacheBuildRuns) {
         this.cacheBuildRuns = cacheBuildRuns;
+    }
+
+    /**
+     * @return - A {@link Boolean} indicating if the user has configured Datadog to use AWS instance as hostname
+     */
+    public boolean doUseAwsInstanceHostname() {
+        return useAwsInstanceHostname;
+    }
+
+
+    /**
+     * Set the checkbox in the UI, used for Jenkins data binding
+     *
+     * @param useAwsInstanceHostname - The checkbox status (checked/unchecked)
+     */
+    @DataBoundSetter
+    public void setUseAwsInstanceHostname(boolean useAwsInstanceHostname) {
+        this.useAwsInstanceHostname = useAwsInstanceHostname;
     }
 
     /**

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -467,6 +467,40 @@ public class DatadogUtilities {
         return result;
     }
 
+    public static String getAwsInstanceID() throws IOException {
+        String metadataUrl = "http://169.254.169.254/latest/meta-data/instance-id";
+        HttpURLConnection conn = null;
+        String instance_id = "";
+        // Make request
+        conn = getHttpURLConnection(new URL(metadataUrl), 300);
+        conn.setRequestMethod("GET");
+
+        // Get response
+        BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), "utf-8"));
+        StringBuilder result = new StringBuilder();
+        String line;
+        while ((line = rd.readLine()) != null) {
+            result.append(line);
+        }
+        rd.close();
+
+        // Validate
+        instance_id = result.toString();
+        try {
+            if (conn.getResponseCode() == 404) {
+                logger.fine("Could not retrieve AWS instance ID");
+            }
+            conn.disconnect();
+        } catch (IOException e) {
+            logger.info("Failed to inspect HTTP response when getting AWS Instance ID");
+        }
+
+        if (instance_id.equals("")) {
+            return null;
+        }
+        return instance_id;
+    }
+
     /**
      * Getter function to return either the saved hostname global configuration,
      * or the hostname that is set in the Jenkins host itself. Returns null if no
@@ -475,6 +509,8 @@ public class DatadogUtilities {
      * Tries, in order:
      * Jenkins configuration
      * Jenkins hostname environment variable
+     * AWS instance ID, if enabled
+     * System hostname environment variable
      * Unix hostname via `/bin/hostname -f`
      * Localhost hostname
      *
@@ -504,6 +540,27 @@ public class DatadogUtilities {
                 return hostname;
             }
         }
+
+        final DatadogGlobalConfiguration datadogGlobalConfig = getDatadogGlobalDescriptor();
+        if (datadogGlobalConfig != null){
+            if (datadogGlobalConfig.doUseAwsInstanceHostname()) {
+                try {
+                    hostname = getAwsInstanceID();
+                } catch (IOException e) {
+                    logger.fine("Error retrieving AWS hostname: " + e);
+                }
+                if (hostname != null) {
+                    logger.fine("Using AWS instance ID as hostname. Hostname: " + hostname);
+                    return hostname;
+                }
+            }
+        }
+
+        if (isValidHostname(hostname)) {
+            logger.fine("Using hostname found in $HOSTNAME controller environment variable. Hostname: " + hostname);
+            return hostname;
+        }
+
         hostname = System.getenv("HOSTNAME");
         if (isValidHostname(hostname)) {
             logger.fine("Using hostname found in $HOSTNAME controller environment variable. Hostname: " + hostname);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -470,7 +470,7 @@ public class DatadogUtilities {
     public static String getAwsInstanceID() throws IOException {
         String metadataUrl = "http://169.254.169.254/latest/meta-data/instance-id";
         HttpURLConnection conn = null;
-        String instance_id = "";
+        String instance_id = null;
         // Make request
         conn = getHttpURLConnection(new URL(metadataUrl), 300);
         conn.setRequestMethod("GET");
@@ -543,7 +543,7 @@ public class DatadogUtilities {
 
         final DatadogGlobalConfiguration datadogGlobalConfig = getDatadogGlobalDescriptor();
         if (datadogGlobalConfig != null){
-            if (datadogGlobalConfig.doUseAwsInstanceHostname()) {
+            if (datadogGlobalConfig.isUseAwsInstanceHostname()) {
                 try {
                     hostname = getAwsInstanceID();
                 } catch (IOException e) {

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -128,6 +128,10 @@
             <f:checkbox title="Cache Build Runs" field="cacheBuildRuns" default="true" />
         </f:entry>
 
+        <f:entry title="Use AWS Instance ID" description="Attempt to use AWS instance ID when resolving hostname">
+            <f:checkbox title="Use AWS Instance ID" field="useAwsInstanceHostname" default="false" />
+        </f:entry>
+
         <f:entry title="System Events">
           <f:entry description="Send system events like Node changes of states.">
             <f:checkbox title="Send System events" field="emitSystemEvents" default="true" />

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration/config.jelly
@@ -124,13 +124,15 @@
         </f:entry>
 
 
+        <f:entry title="Use AWS Instance ID" description="Attempt to use AWS instance ID when resolving hostname">
+            <f:checkbox title="Use AWS Instance ID" field="useAwsInstanceHostname" default="false" />
+        </f:entry>
+
+
         <f:entry title="Cache Build Runs" description="Cache build runs when calculating pause duration">
             <f:checkbox title="Cache Build Runs" field="cacheBuildRuns" default="true" />
         </f:entry>
 
-        <f:entry title="Use AWS Instance ID" description="Attempt to use AWS instance ID when resolving hostname">
-            <f:checkbox title="Use AWS Instance ID" field="useAwsInstanceHostname" default="false" />
-        </f:entry>
 
         <f:entry title="System Events">
           <f:entry description="Send system events like Node changes of states.">


### PR DESCRIPTION
### What does this PR do?

Adds option to use AWS instance ID as hostname

### Description of the Change

When enabled, the plugin will attempt to use the AWS instance ID as the hostname. 

### Alternate Designs

Don't add an option, and only call the method when on an AWS host

some drawbacks to this approach are:
- difficult to detect accurately and when jenkins has migrated hosts
- not backwards compatible

some benefits to this approach are: 
- closer to the agent behavior
- less configuration bloat
### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

