### PR TITLE
Fix file descriptor leak in logger reinitialisation logic and print stack trace in severe logs

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -39,6 +39,7 @@ import hudson.util.LogTaskListener;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
 import org.datadog.jenkins.plugins.datadog.model.GitCommitAction;
 import org.datadog.jenkins.plugins.datadog.model.GitRepositoryAction;
@@ -876,16 +877,12 @@ public class DatadogUtilities {
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
     public static void severe(Logger logger, Throwable e, String message){
-        if(message == null){
-            message = e != null ? "An unexpected error occurred": "";
+        if (e != null) {
+            String stackTrace = ExceptionUtils.getStackTrace(e);
+            message = (message != null ? message : "An unexpected error occurred: ") + stackTrace;
         }
-        if(!message.isEmpty()) {
+        if (StringUtils.isNotEmpty(message)) {
             logger.severe(message);
-        }
-        if(e != null) {
-            StringWriter sw = new StringWriter();
-            e.printStackTrace(new PrintWriter(sw));
-            logger.info(message + ": " + sw.toString());
         }
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
@@ -290,6 +290,8 @@ public class DatadogAgentClient implements DatadogClient {
         }
         try {
             logger.info("Re/Initialize Datadog-Plugin Logger: hostname = " + this.hostname + ", logCollectionPort = " + this.logCollectionPort);
+            // need to close existing logger since it has a socket opened - not closing it leads to a file descriptor leak
+            close(this.ddLogger);
             this.ddLogger = Logger.getLogger("Datadog-Plugin Logger");
             this.ddLogger.setUseParentHandlers(false);
             //Remove all existing Handlers
@@ -316,6 +318,24 @@ public class DatadogAgentClient implements DatadogClient {
             return false;
         }
         return true;
+    }
+
+
+    private void close(Logger logger) {
+        if (logger == null) {
+            return;
+        }
+        Handler[] handlers = logger.getHandlers();
+        if (handlers == null) {
+            return;
+        }
+        for (Handler handler : handlers) {
+            try {
+                handler.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Fixes a file descriptor leak in logger reinitialisation logic.
Whenever there is problem with the logger, it is reinitialized.
Reinitialisation entails creating a new logger instance.
The problem is that the old instance is not being closed.
The logger uses a `SocketHandler`, which opens a socket.
This handler needs to be closed, otherwise file descriptor that corresponds to the opened socket "leaks".
If the logger is reinitialised many times the process runs out of available file descriptors.

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

Whenever the logger is reinitialised, previously existing instance (if any) is properly closed.

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Tested manually using a dockerized Jenkins instance.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

`DatadogUtilities#severe` was changed to log exception stack trace: the stack trace is the most valuable and useful piece of info, and it is rather troublesome to ask customers to tweak their log levels and reproduce their problem all over again because the exception was not logged the first time.

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

