### PR TITLE
changed upper bound on timeout to allow for small discrepancy

### DIFF
--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListenerTest.java
@@ -186,7 +186,7 @@ public class DatadogGraphListenerTest extends DatadogTraceAbstractTest {
                 // we test it's at least 10s.
                 double pauseValue = clientStub.assertMetricGetValue("jenkins.job.stage_pause_duration", hostname, expectedTags);
                 assertTrue(pauseValue > 10000);
-                assertTrue(pauseValue <= 11000);
+                assertTrue(pauseValue <= 11100);
             } else {
                 clientStub.assertMetric("jenkins.job.stage_pause_duration", 0.0, hostname, expectedTags);
             }


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Fixes a flaky test where the upper bound of the timeout duration is exactly 11 seconds although realistically, it won't always be 11 seconds and might be slightly higher. 

### Description of the Change

Increase the upper bound of the timeout to 11.1 seconds, to allow for small variance of the actual pause duration.

### Alternate Designs

### Possible Drawbacks

The upper bound may be too lenient although I found it to be a good sweetspot.

### Verification Process

Ran the test 10 times on the current master repo and passed all 10 times.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

