### PR TITLE
Merge 5.4.2 back into default branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <url>https://github.com/jenkinsci/datadog-plugin</url>
   <groupId>org.datadog.jenkins.plugins</groupId>
   <artifactId>datadog</artifactId>
-  <version>5.4.2-SNAPSHOT</version>
+  <version>5.4.2</version>
   <packaging>hpi</packaging>
 
   <properties>
@@ -46,7 +46,7 @@
     <connection>scm:git:git://github.com/jenkinsci/datadog-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/datadog-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/datadog-plugin</url>
-    <tag>datadog-3.0.0</tag>
+    <tag>datadog-5.4.2</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <url>https://github.com/jenkinsci/datadog-plugin</url>
   <groupId>org.datadog.jenkins.plugins</groupId>
   <artifactId>datadog</artifactId>
-  <version>5.4.2</version>
+  <version>5.4.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>
@@ -46,7 +46,7 @@
     <connection>scm:git:git://github.com/jenkinsci/datadog-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/datadog-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/datadog-plugin</url>
-    <tag>datadog-5.4.2</tag>
+    <tag>datadog-3.0.0</tag>
   </scm>
 
   <repositories>

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalConfiguration.java
@@ -406,7 +406,7 @@ public class DatadogGlobalConfiguration extends GlobalConfiguration {
             @QueryParameter("targetCredentialsApiKey") final String targetCredentialsApiKey, 
             @QueryParameter("targetApiURL") final String targetApiURL)
             throws IOException, ServletException {
-
+        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
         final Secret secret = findSecret(targetApiKey, targetCredentialsApiKey);
         if (DatadogHttpClient.validateDefaultIntakeConnection(targetApiURL, secret)) {
             return FormValidation.ok("Great! Your API key is valid.");


### PR DESCRIPTION
https://github.com/jenkinsci/datadog-plugin/releases/tag/datadog-5.4.2 was created from a branch. This PR merges the security fix and release commits back into the default branch.

This PR should be merged using merge-commit, not using squash-commit or rebase-commit, to ensure the commits related to the release are in the history of the default branch.

To prevent accidental releases without the fix, I've also locked the default branch here: https://github.com/jenkinsci/datadog-plugin/settings/branches 