### PR TITLE
Add backoff to agent logger/statsd/http clients

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -879,7 +879,7 @@ public class DatadogUtilities {
     public static void severe(Logger logger, Throwable e, String message){
         if (e != null) {
             String stackTrace = ExceptionUtils.getStackTrace(e);
-            message = (message != null ? message : "An unexpected error occurred: ") + stackTrace;
+            message = (message != null ? message : "An unexpected error occurred") + ": " + stackTrace;
         }
         if (StringUtils.isNotEmpty(message)) {
             logger.severe(message);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -39,6 +39,7 @@ import hudson.util.LogTaskListener;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.datadog.jenkins.plugins.datadog.model.CIGlobalTagsAction;
 import org.datadog.jenkins.plugins.datadog.model.GitCommitAction;
 import org.datadog.jenkins.plugins.datadog.model.GitRepositoryAction;
@@ -876,16 +877,12 @@ public class DatadogUtilities {
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
     public static void severe(Logger logger, Throwable e, String message){
-        if(message == null){
-            message = e != null ? "An unexpected error occurred": "";
+        if (e != null) {
+            String stackTrace = ExceptionUtils.getStackTrace(e);
+            message = (message != null ? message : "An unexpected error occurred: ") + stackTrace;
         }
-        if(!message.isEmpty()) {
+        if (StringUtils.isNotEmpty(message)) {
             logger.severe(message);
-        }
-        if(e != null) {
-            StringWriter sw = new StringWriter();
-            e.printStackTrace(new PrintWriter(sw));
-            logger.info(message + ": " + sw.toString());
         }
     }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/clients/DatadogAgentClient.java
@@ -290,6 +290,8 @@ public class DatadogAgentClient implements DatadogClient {
         }
         try {
             logger.info("Re/Initialize Datadog-Plugin Logger: hostname = " + this.hostname + ", logCollectionPort = " + this.logCollectionPort);
+            // need to close existing logger since it has a socket opened - not closing it leads to a file descriptor leak
+            close(this.ddLogger);
             this.ddLogger = Logger.getLogger("Datadog-Plugin Logger");
             this.ddLogger.setUseParentHandlers(false);
             //Remove all existing Handlers
@@ -316,6 +318,24 @@ public class DatadogAgentClient implements DatadogClient {
             return false;
         }
         return true;
+    }
+
+
+    private void close(Logger logger) {
+        if (logger == null) {
+            return;
+        }
+        Handler[] handlers = logger.getHandlers();
+        if (handlers == null) {
+            return;
+        }
+        for (Handler handler : handlers) {
+            try {
+                handler.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Adds exponential backoff to re-initialisation of HTTP logger, StatsD client and HTTP client that are used to communicate with the agent.

A customer might misconfigure their agent integration, in which case one or more of the clients listed above will not be able to initialise properly.
If a client is not fully initialised, every request to it will lead to a re-init attempt.
This is problematic, as initialising these clients is expensive.
The problem is especially pronounced with the logger, as it receives the biggest number of request.
This constant reinitialisation loop can consume a lot of resources (depending on the customer's workload) and lead to severe performance degradation.

While the plugin is not expected to work correctly if it is misconfigured, it should degrade gracefully and should not affect customer's jobs and pipelines.

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

This change adds exponential back-off to initialisation of the three clients listed above.
There is now a delay between re-initialisation attempts, starting at 100 ms and doubling every time initialisation fails, up to a maximum of 60 seconds.
In case initialisation is successful, the delay is reset back to 100 ms so that subsequent errors lead to faster re-tries.

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

In case there is an intermittent network issue, clients will take longer to re-initialise (up to 1 minute in the absolute worst case, that is if the connectivity is lost for a period longer than this).

### Verification Process

Verified manually with a dockerized Jenkins instance.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

