### PR TITLE
When creating a new BuildData instance, use BuildData populated during previous pipeline stages

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -55,16 +55,6 @@ import hudson.tasks.Mailer;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
 import hudson.util.LogTaskListener;
-import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
-import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
-import org.datadog.jenkins.plugins.datadog.traces.BuildSpanManager;
-import org.datadog.jenkins.plugins.datadog.traces.message.TraceSpan;
-import org.datadog.jenkins.plugins.datadog.util.SuppressFBWarnings;
-import org.datadog.jenkins.plugins.datadog.util.TagsUtil;
-import org.datadog.jenkins.plugins.datadog.util.git.GitUtils;
-import org.jenkinsci.plugins.gitclient.GitClient;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.Charset;
@@ -74,6 +64,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
+import org.datadog.jenkins.plugins.datadog.traces.BuildSpanAction;
+import org.datadog.jenkins.plugins.datadog.traces.BuildSpanManager;
+import org.datadog.jenkins.plugins.datadog.traces.message.TraceSpan;
+import org.datadog.jenkins.plugins.datadog.util.SuppressFBWarnings;
+import org.datadog.jenkins.plugins.datadog.util.TagsUtil;
+import org.datadog.jenkins.plugins.datadog.util.git.GitUtils;
+import org.jenkinsci.plugins.gitclient.GitClient;
 
 public class BuildData implements Serializable {
 
@@ -228,6 +228,50 @@ public class BuildData implements Serializable {
         if(buildSpan !=null) {
             setTraceId(Long.toUnsignedString(buildSpan.context().getTraceId()));
             setSpanId(Long.toUnsignedString(buildSpan.context().getSpanId()));
+        }
+
+        BuildSpanAction buildSpanAction = run.getAction(BuildSpanAction.class);
+        if (buildSpanAction != null) {
+            getMissingGitValuesFrom(buildSpanAction.getBuildData());
+        }
+    }
+
+    private void getMissingGitValuesFrom(BuildData previousData) {
+        if (branch == null) {
+            branch = previousData.branch;
+        }
+        if (gitUrl == null) {
+            gitUrl = previousData.gitUrl;
+        }
+        if (gitCommit == null) {
+            gitCommit = previousData.gitCommit;
+        }
+        if (gitMessage == null) {
+            gitMessage = previousData.gitMessage;
+        }
+        if (gitAuthorName == null) {
+            gitAuthorName = previousData.gitAuthorName;
+        }
+        if (gitAuthorEmail == null) {
+            gitAuthorEmail = previousData.gitAuthorEmail;
+        }
+        if (gitAuthorDate == null) {
+            gitAuthorDate = previousData.gitAuthorDate;
+        }
+        if (gitCommitterName == null) {
+            gitCommitterName = previousData.gitCommitterName;
+        }
+        if (gitCommitterEmail == null) {
+            gitCommitterEmail = previousData.gitCommitterEmail;
+        }
+        if (gitCommitterDate == null) {
+            gitCommitterDate = previousData.gitCommitterDate;
+        }
+        if (gitDefaultBranch == null) {
+            gitDefaultBranch = previousData.gitDefaultBranch;
+        }
+        if (gitTag == null) {
+            gitTag = previousData.gitTag;
         }
     }
 


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Update `BuildData` creation logic: when a new instance is created, a check is made to see whether the associated run already refers to another instance that was created and updated during previous pipeline stages.
If there is a previously created instance, it is used to populate Git values in the new instance, in case they are missing.

For instance, if there are environment variables that are set inside a pipeline stage (e.g. Git branch and repo URL that are set during SCM checkout), these variables will only be available during that stage: later stages will not be able to use them.
The fallback mechanism ensures that these variables whenever a new `BuildData` instance is created at some later point.

This fixes https://datadoghq.atlassian.net/browse/AGENT-10162

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Verified manually using a dockerized Jenkins instance.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

