### PR TITLE
Fix stack overflow on initialising DatadogTaskListenerDecorator

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -262,8 +262,8 @@ public class BuildData implements Serializable {
 
         List<EnvActionImpl> envActions = run.getActions(EnvActionImpl.class);
         for (EnvActionImpl envAction : envActions) {
-            EnvVars environment = envAction.getEnvironment();
-            mergedVars.putAll(environment);
+            Map<String, String> overriddenEnvironment = envAction.getOverriddenEnvironment();
+            mergedVars.putAll(overriddenEnvironment);
         }
 
         Map<String, String> envVars;


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Fixes stack overflow on initialising `DatadogTaskListenerDecorator`:
1. BuildData instance construction is started
2. EnvActionImpl#getEnvironment() is called
3. Inside this call run's TaskListener is initialized
4. Once TaskListener is created, it is wrapped with `DatadogTaskListenerDecorator`
5. The decorator starts creating another BuildData instance
6. The steps repeat indefinitely from point 1

The example stack trace can be found [here](https://gist.github.com/lemeurherve/eaf08053a133733a829c24ca0eec7117).

The `EnvActionImpl#getEnvironment()` call is replaced with `EnvActionImpl#getOverriddenEnvironment()`, which only returns the env vars that were overridden in that action.
The latter call does not trigger task listener initialisation, and allows to examine the right env vars.

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

