### PR TITLE
added extra conditions for counting executors

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogComputerPublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogComputerPublisher.java
@@ -98,9 +98,9 @@ public class DatadogComputerPublisher extends PeriodicWork {
                     nodeOnline++;
                     metrics.gauge("jenkins.node_status.up", 1, hostname, tags);
                 }
-                int executorCount = computer.countExecutors();
-                int inUse = computer.countBusy();
-                int free = computer.countIdle();
+                int executorCount = computer.isOnline() ? computer.countExecutors() : 0;
+                int inUse = computer.isOnline() ? computer.countBusy() : 0;
+                int free = ((computer.isOnline() || computer.isConnecting()) && computer.isAcceptingTasks()) ? computer.countIdle() : 0;
 
                 metrics.gauge("jenkins.node_status.count", 1, hostname, tags);
 

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogComputerPublisherTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogComputerPublisherTest.java
@@ -48,6 +48,10 @@ public class DatadogComputerPublisherTest {
         
         client.assertMetric("jenkins.node_status.count", 1, hostname, expectedTags);
         client.assertMetric("jenkins.node_status.up", 1, hostname, expectedTags);
+        client.assertMetric("jenkins.executor.count", 2, hostname, expectedTags);
+        client.assertMetric("jenkins.executor.in_use", 0, hostname, expectedTags);
+        // All of the executors are online, so jenkins.executor.count == jenkins.executor.in_use + jenkins.executor.free
+        client.assertMetric("jenkins.executor.free", 2, hostname, expectedTags);
         
         // if we set the computer to offline, the metrics should reflect that
         for (Computer computer: jenkins.jenkins.getComputers()){
@@ -56,7 +60,9 @@ public class DatadogComputerPublisherTest {
         computerPublisher.doRun();
         client.assertMetric("jenkins.node_status.count", 1, hostname, expectedTags);
         client.assertMetric("jenkins.node_status.up", 0, hostname, expectedTags);
-        
+        client.assertMetric("jenkins.executor.count", 0, hostname, expectedTags);
+        client.assertMetric("jenkins.executor.in_use", 0, hostname, expectedTags);
+        client.assertMetric("jenkins.executor.free", 0, hostname, expectedTags);
     }
     
     @Test


### PR DESCRIPTION
### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->
Addresses issue [#434](https://github.com/jenkinsci/datadog-plugin/issues/434)
### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
This issue arose from calling two different classes: [Computer](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Computer.java#L941) and [ComputerSet](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/ComputerSet.java#L171). Datadog directly calls on the executor methods in Computer.java for each computer, while [Jenkins](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/OverallLoadStatistics.java#L60) calls the ComputerSet.java methods which itself calls Computer.java for each computer. 

However, ComputerSet.java applies some restrictions on when to call the executor methods of Computer.java--**the number of busy executors and the number of total executors only considers online computers, while the number of free executors only considers computers that are either online or connecting, and which is accepting tasks.** As such, in order to mimic how Jenkins counts total, free, and busy executors, this PR adds the ComputerSet.java (and by extension, Jenkins) restrictions to the Datadog plugin's calls to Computer.java. 

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

