### PR TITLE
docs(CHANGELOG) Inform user about the deprecated `retryLogs` JCasC attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ https://github.com/jenkinsci/datadog-plugin/compare/datadog-7.2.1...datadog-8.0.
 * [Fixed] Refactor logs submission. See [#451](https://github.com/jenkinsci/datadog-plugin/pull/451).
 * [Fixed] Delay sending start event for pipelines. See [#461](https://github.com/jenkinsci/datadog-plugin/pull/461).
 
+> [!IMPORTANT]  
+> 💥 The Jenkins Configuration as Code (JCasC) attribute `retryLogs` is not supported anymore.
+>
+> If you use a JCasC YAML configuration, either:
+> - Ensure the attribute `unclassified.datadogGlobalConfiguration.retryLogs` is removed
+> - Or set `unclassified.datadogGlobalConfiguration.deprecated` to `warn` to avoid the error
+> ```text
+> Error Loading Configuration 'retryLogs' is deprecated
+> ```
+>
+> See https://github.com/jenkinsci/datadog-plugin/issues/467 for details
+
 ## 7.2.1 / 2024-09-24
 ### Details
 https://github.com/jenkinsci/datadog-plugin/compare/datadog-7.2.0...datadog-7.2.1


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

As proposed in https://github.com/jenkinsci/datadog-plugin/issues/467#issuecomment-2475715436,
this PR updates the changelog to describe the breaking change for 8.0.0 related to the deprecated `retryLogs` JCasC attribute.

It advertises the change to Jenkins admins. upgrading their Datadog plugin to let them plan their upgrade without breaking their controller during the restart phase.

### Description of the Change

I've added an admonition to avoid breaking the standard Datadog writing style while keeping a visual indicator when reading quickly.

It gives a sentence stating the fact of the breaking change, and a list of possible actionnable, along with a link to https://github.com/jenkinsci/datadog-plugin/issues/467 for details.

It looks like the following (in rendering):

<img width="1464" alt="Capture d’écran 2024-11-14 à 13 45 34" src="https://github.com/user-attachments/assets/95ab1d7e-465c-48dd-b41b-575921b4d351">


### Alternate Designs

N.A.

### Possible Drawbacks

N.A.

### Verification Process

- Checked rendering
- Ran one of the actionable on a real life instance (https://github.com/jenkins-infra/helpdesk/issues/4377)

### Additional Notes

N.A.

### Release Notes

N.A. (not worth being in the releases note to be honest)

### Review checklist (to be filled by reviewers)

- ~[ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)~
- [x] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

