### PR TITLE
Add NPE checks for jobs started with scripting

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -923,12 +923,19 @@ public class DatadogUtilities {
      * Never returns the node itself.
      */
     public static BlockStartNode getEnclosingStageNode(FlowNode node) {
-        for (BlockStartNode block : node.iterateEnclosingBlocks()) {
-            if (DatadogUtilities.isStageNode(block)) {
-                return block;
+        try {
+            for (BlockStartNode block : node.iterateEnclosingBlocks()) {
+                if (DatadogUtilities.isStageNode(block)) {
+                    return block;
+                }
             }
+            return null;
+
+        } catch (NullPointerException e) {
+            // FlowNode#iterateEnclosingBlocks may throw an NPE
+            severe(logger, e, "Error while looking for enclosing stage node");
+            return null;
         }
-        return null;
     }
 
     /**

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogBaseBuildLogic.java
@@ -119,7 +119,11 @@ public abstract class DatadogBaseBuildLogic {
         Queue<FlowNode> nodes = new ArrayDeque<>(heads);
         while (!nodes.isEmpty()) {
             FlowNode node = nodes.poll();
-            nodes.addAll(node.getParents());
+            for (FlowNode parent : node.getParents()) {
+                if (parent != null){
+                    nodes.add(parent);
+                }
+            }
 
             if (!(node instanceof BlockEndNode)) {
                 continue;


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Adds guardrails some NPEs observed in customers' logs.
I could not reproduce the errors, but they're likely caused by pipelines/jobs that are submitted with scripting.
Some of the errors happen inside core Jenkins code, so they had to be caught rather than prevented.

Below are the examples of the 3 exceptions fixed:
```
2024-11-12 16:13:42.982 +0000: java.lang.NullPointerException: Cannot invoke "org.jenkinsci.plugins.workflow.graph.FlowNode.getId()" because "current" is null
	at PluginClassLoader for workflow-api//org.jenkinsci.plugins.workflow.graph.StandardGraphLookupView.bruteForceScanForEnclosingBlock(StandardGraphLookupView.java:126)
	at PluginClassLoader for workflow-api//org.jenkinsci.plugins.workflow.graph.StandardGraphLookupView.findEnclosingBlockStart(StandardGraphLookupView.java:199)
	at PluginClassLoader for workflow-api//org.jenkinsci.plugins.workflow.graph.GraphLookupView$EnclosingBlocksIterable$EnclosingBlocksIterator.<init>(GraphLookupView.java:66)
	at PluginClassLoader for workflow-api//org.jenkinsci.plugins.workflow.graph.GraphLookupView$EnclosingBlocksIterable.iterator(GraphLookupView.java:100)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.DatadogUtilities.getEnclosingStageNode(DatadogUtilities.java:926)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.model.PipelineStepData.<init>(PipelineStepData.java:135)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.model.PipelineStepData.<init>(PipelineStepData.java:93)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.listeners.DatadogGraphListener.buildStepData(DatadogGraphListener.java:296)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.listeners.DatadogGraphListener.processNode(DatadogGraphListener.java:215)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.listeners.DatadogGraphListener.processNode(DatadogGraphListener.java:194)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.listeners.DatadogGraphListener.onNewHead(DatadogGraphListener.java:88)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1582)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.setNewHead(FlowHead.java:164)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onProgramEnd(CpsFlowExecution.java:1359)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.croak(CpsFlowExecution.java:936)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.loadProgramFailed(CpsFlowExecution.java:919)
	at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:847)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:719)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:577)
	at hudson.model.RunMap.retrieve(RunMap.java:273)
	at hudson.model.RunMap.retrieve(RunMap.java:65)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:703)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:685)
	at jenkins.model.lazy.AbstractLazyLoadRunMap.getByNumber(AbstractLazyLoadRunMap.java:579)
	at hudson.model.RunMap.getById(RunMap.java:237)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.run(WorkflowRun.java:968)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.get(WorkflowRun.java:980)
	at PluginClassLoader for workflow-api//org.jenkinsci.plugins.workflow.flow.FlowExecutionList.resume(FlowExecutionList.java:226)
	at PluginClassLoader for workflow-api//org.jenkinsci.plugins.workflow.flow.FlowExecutionList$ItemListenerImpl.onLoaded(FlowExecutionList.java:217)
	at jenkins.model.Jenkins.<init>(Jenkins.java:1050)
	at hudson.model.Hudson.<init>(Hudson.java:86)
	at hudson.model.Hudson.<init>(Hudson.java:82)
	at hudson.WebAppMain$3.run(WebAppMain.java:248)
```

```
2024-11-12 16:13:44.382 +0000: java.lang.NullPointerException: Cannot invoke "org.jenkinsci.plugins.workflow.graph.FlowNode.getId()" because "parent" is null
	at PluginClassLoader for pipeline-rest-api//com.cloudbees.workflow.rest.external.AtomFlowNodeExt.addParentNodeRefs(AtomFlowNodeExt.java:87)
	at PluginClassLoader for pipeline-rest-api//com.cloudbees.workflow.rest.external.AtomFlowNodeExt.create(AtomFlowNodeExt.java:79)
	at PluginClassLoader for pipeline-rest-api//com.cloudbees.workflow.rest.external.ChunkVisitor.makeAtomNode(ChunkVisitor.java:68)
	at PluginClassLoader for pipeline-rest-api//com.cloudbees.workflow.rest.external.ChunkVisitor.atomNode(ChunkVisitor.java:154)
	at PluginClassLoader for workflow-api//org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner.fireVisitChunkCallbacks(ForkScanner.java:779)
	at PluginClassLoader for workflow-api//org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner.visitSimpleChunks(ForkScanner.java:797)
	at PluginClassLoader for workflow-api//org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner.visitSimpleChunks(ForkScanner.java:661)
	at PluginClassLoader for pipeline-rest-api//com.cloudbees.workflow.rest.external.RunExt.createNew(RunExt.java:323)
	at PluginClassLoader for pipeline-rest-api//com.cloudbees.workflow.rest.external.RunExt.create(RunExt.java:311)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.listeners.DatadogBuildListener.getRunExtForRun(DatadogBuildListener.java:543)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.listeners.DatadogBuildListener.onCompleted(DatadogBuildListener.java:319)
	at hudson.model.listeners.RunListener.lambda$fireCompleted$0(RunListener.java:223)
	at jenkins.util.Listeners.lambda$notify$0(Listeners.java:59)
	at jenkins.util.Listeners.notify(Listeners.java:67)
	at hudson.model.listeners.RunListener.fireCompleted(RunListener.java:221)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.finish(WorkflowRun.java:645)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$FailOnLoadListener.lambda$onNewHead$0(WorkflowRun.java:1053)
	at jenkins.security.ImpersonatingScheduledExecutorService$1.run(ImpersonatingScheduledExecutorService.java:67)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

```
2024-11-12 16:13:44.772 +0000: java.lang.NullPointerException
	at java.base/java.util.ArrayDeque.addLast(ArrayDeque.java:303)
	at java.base/java.util.Collections$SingletonList.forEach(Collections.java:4966)
	at java.base/java.util.ArrayDeque.copyElements(ArrayDeque.java:329)
	at java.base/java.util.ArrayDeque.addAll(ArrayDeque.java:324)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.traces.DatadogBaseBuildLogic.traverseStages(DatadogBaseBuildLogic.java:122)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.traces.DatadogBaseBuildLogic.getStageBreakdown(DatadogBaseBuildLogic.java:93)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.traces.DatadogWebhookBuildLogic.toJson(DatadogWebhookBuildLogic.java:135)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.traces.write.TraceWriteStrategyImpl.serialize(TraceWriteStrategyImpl.java:52)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.traces.write.AgentTraceWriteStrategy.serialize(AgentTraceWriteStrategy.java:53)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.traces.write.TraceWriter.submitBuild(TraceWriter.java:54)
	at PluginClassLoader for datadog//org.datadog.jenkins.plugins.datadog.listeners.DatadogBuildListener.onFinalized(DatadogBuildListener.java:417)
	at hudson.model.listeners.RunListener.lambda$fireFinalized$3(RunListener.java:260)
	at jenkins.util.Listeners.lambda$notify$0(Listeners.java:59)
	at jenkins.util.Listeners.notify(Listeners.java:67)
	at hudson.model.listeners.RunListener.fireFinalized(RunListener.java:258)
	at hudson.model.Run.onEndBuilding(Run.java:2007)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.finish(WorkflowRun.java:670)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$FailOnLoadListener.lambda$onNewHead$0(WorkflowRun.java:1053)
	at jenkins.security.ImpersonatingScheduledExecutorService$1.run(ImpersonatingScheduledExecutorService.java:67)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

