### PR TITLE
Add a guard check against stack overflow when initializing BuildData

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
@@ -93,19 +93,7 @@ public class DatadogBuildListener extends RunListener<Run> {
             run.addAction(new TraceInfoAction());
             run.addAction(new PipelineQueueInfoAction());
 
-            // Collect Build Data
-            BuildData buildData;
-            try {
-                buildData = new BuildData(run, null);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                DatadogUtilities.severe(logger, e, "Interrupted while trying to parse initialized build data");
-                return;
-            } catch (IOException e) {
-                DatadogUtilities.severe(logger, e, "Failed to parse initialized build data");
-                return;
-            }
-
+            BuildData buildData = BuildData.create(run, null);
             TraceSpan.TraceSpanContext buildSpanContext = new TraceSpan.TraceSpanContext();
             BuildSpanManager.get().put(buildData.getBuildTag(""), buildSpanContext);
 
@@ -206,18 +194,7 @@ public class DatadogBuildListener extends RunListener<Run> {
                 waitingMs = null;
             }
 
-            // Collect Build Data
-            BuildData buildData;
-            try {
-                buildData = new BuildData(run, listener);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                DatadogUtilities.severe(logger, e, "Interrupted while trying to parse started build data");
-                return;
-            } catch (IOException e) {
-                DatadogUtilities.severe(logger, e, "Failed to parse started build data");
-                return;
-            }
+            BuildData buildData = BuildData.create(run, listener);
 
             // Send an event
             if (DatadogUtilities.shouldSendEvent(BuildStartedEventImpl.BUILD_STARTED_EVENT_NAME)) {
@@ -289,14 +266,7 @@ public class DatadogBuildListener extends RunListener<Run> {
         }
 
         try (MetricsClient metrics = client.metrics()) {
-            // Collect Build Data
-            BuildData buildData;
-            try {
-                buildData = new BuildData(run, listener);
-            } catch (IOException | InterruptedException e) {
-                DatadogUtilities.severe(logger, e, "Failed to parse completed build data");
-                return;
-            }
+            BuildData buildData = BuildData.create(run, listener);
 
             final boolean shouldSendEvent = DatadogUtilities.shouldSendEvent(BuildFinishedEventImpl.BUILD_FINISHED_EVENT_NAME);
             if (shouldSendEvent) {
@@ -398,19 +368,7 @@ public class DatadogBuildListener extends RunListener<Run> {
                 return;
             }
 
-            // Collect Build Data
-            BuildData buildData;
-            try {
-                buildData = new BuildData(run, null);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                DatadogUtilities.severe(logger, e, "Interrupted while trying to parse finalized build data");
-                return;
-            } catch (IOException e) {
-                DatadogUtilities.severe(logger, e, "Failed to parse finalized build data");
-                return;
-            }
-
+            BuildData buildData = BuildData.create(run, null);
             traceWriter.submitBuild(buildData, run);
             logger.fine("End DatadogBuildListener#onFinalized");
 
@@ -440,18 +398,7 @@ public class DatadogBuildListener extends RunListener<Run> {
                 return;
             }
 
-            // Collect Build Data
-            BuildData buildData;
-            try {
-                buildData = new BuildData(run, null);
-            } catch (InterruptedException e){
-                Thread.currentThread().interrupt();
-                DatadogUtilities.severe(logger, e, "Interrupted while trying to parse deleted build data");
-                return;
-            } catch (IOException e) {
-                DatadogUtilities.severe(logger, e, "Failed to parse deleted build data");
-                return;
-            }
+            BuildData buildData = BuildData.create(run, null);
 
             // If the build already complete, this could be a Jenkins cleanup operation
             if (buildData.isCompleted()) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogGraphListener.java
@@ -130,7 +130,7 @@ public class DatadogGraphListener implements GraphListener {
                 }
             }
 
-            BuildData buildData = new BuildData(run, flowNode.getExecution().getOwner().getListener());
+            BuildData buildData = BuildData.create(run, flowNode.getExecution().getOwner().getListener());
             if (hostname == null) {
                 hostname = buildData.getHostname(DatadogUtilities.getHostname(null));
             }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSCMListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogSCMListener.java
@@ -105,18 +105,7 @@ public class DatadogSCMListener extends SCMListener {
                         + (scm != null ? scm.getType() : null));
             }
 
-            // Collect Build Data
-            BuildData buildData;
-            try {
-                buildData = new BuildData(build, listener);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                DatadogUtilities.severe(logger, e, "Interrupted while trying to parse checked out build data");
-                return;
-            } catch (IOException e) {
-                DatadogUtilities.severe(logger, e, "Failed to parse checked out build data");
-                return;
-            }
+            BuildData buildData = BuildData.create(build, listener);
 
             // We have Git info available now - submit a pipeline event so the backend could update its data
             if (DatadogUtilities.getDatadogGlobalDescriptor().getEnableCiVisibility()) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogStepListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogStepListener.java
@@ -345,7 +345,7 @@ public class DatadogStepListener implements StepListener {
             return;
         }
         try {
-            BuildData buildData = new BuildData(run, null);
+            BuildData buildData = BuildData.create(run, null);
             traceWriter.submitBuild(buildData, run);
 
         } catch (InterruptedException e) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogConsoleLogFilter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogConsoleLogFilter.java
@@ -60,17 +60,15 @@ public class DatadogConsoleLogFilter extends ConsoleLogFilter implements Seriali
             }
 
             if (DatadogUtilities.isJobTracked(build)) {
-                DatadogWriter writer = new DatadogWriter(new BuildData(build, null));
+                DatadogWriter writer = new DatadogWriter(BuildData.create(build, null));
                 return new DatadogOutputStream(outputStream, writer);
             } else if (DatadogUtilities.isJobTracked(run)) {
-                DatadogWriter writer = new DatadogWriter(new BuildData(run, null));
+                DatadogWriter writer = new DatadogWriter(BuildData.create(run, null));
                 return new DatadogOutputStream(outputStream, writer);
             } else {
                 return outputStream;
             }
-        } catch (InterruptedException e){
-            Thread.currentThread().interrupt();
-            DatadogUtilities.severe(logger, e, "Interrupted while trying to wrap logger, logs will not be collected");
+
         } catch (Exception e){
             DatadogUtilities.severe(logger, e, "Failed to wrap logger, logs will not be collected");
         }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogTaskListenerDecorator.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogTaskListenerDecorator.java
@@ -41,17 +41,11 @@ import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
 public class DatadogTaskListenerDecorator extends TaskListenerDecorator {
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = Logger.getLogger(DatadogTaskListenerDecorator.class.getName());
-    private BuildData buildData;
+
+    private final BuildData buildData;
 
     public DatadogTaskListenerDecorator(WorkflowRun run) {
-        try {
-            this.buildData = new BuildData(run, null);
-        } catch (InterruptedException e){
-            Thread.currentThread().interrupt();
-            DatadogUtilities.severe(LOGGER, e, null);
-        } catch (Exception e) {
-            DatadogUtilities.severe(LOGGER, e, null);
-        }
+        this.buildData = BuildData.create(run, null);
     }
 
     @Nonnull

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/logs/DatadogWriter.java
@@ -38,15 +38,16 @@ import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 
 public class DatadogWriter {
 
     private static final Logger logger = Logger.getLogger(DatadogWriter.class.getName());
 
-    private Charset charset;
-    private BuildData buildData;
+    private final Charset charset;
+    private final BuildData buildData;
 
-    public DatadogWriter(BuildData buildData) {
+    public DatadogWriter(@Nonnull BuildData buildData) {
         this.charset = buildData.getCharset();
         this.buildData = buildData;
     }
@@ -61,7 +62,7 @@ public class DatadogWriter {
                 return;
             }
 
-            JSONObject payload = buildData.addLogAttributes();
+            JSONObject payload = this.buildData.addLogAttributes();
 
             Map<String, Set<String>> ddtags = this.buildData.getTags();
             TagsUtil.addTagToTags(ddtags, "datadog.product", "cipipeline");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -92,7 +92,7 @@ public class BuildData implements Serializable {
     static {
       try {
           // exceptions below should never happen
-          // since constructor exists immediately if run is null
+          // since constructor exits immediately if run is null
           EMPTY = new BuildData(null, null);
       } catch (InterruptedException e) {
           Thread.currentThread().interrupt();

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -128,10 +128,10 @@ public class BuildData implements Serializable {
     public static BuildData create(@Nullable Run<?, ?> run, @Nullable TaskListener listener) {
         if (!BUILD_DATA_BEING_CREATED.get().add(run)) {
             String runName = run != null ? run.getDisplayName() : null;
+            DatadogUtilities.severe(LOGGER, null, "BuildData creation is in progress for run " + runName + "; using empty data");
             // there is another call up the stack that is creating BuildData for the same Run,
             // so the initial caller will get fully populated data
             // (empty data will only be used by the nested calls triggered by the original BuildData init)
-            DatadogUtilities.severe(LOGGER, null, "BuildData creation is in progress for run " + runName + "; using empty data");
             return BuildData.EMPTY;
         }
         try {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -128,6 +128,9 @@ public class BuildData implements Serializable {
     public static BuildData create(@Nullable Run<?, ?> run, @Nullable TaskListener listener) {
         if (!BUILD_DATA_BEING_CREATED.get().add(run)) {
             String runName = run != null ? run.getDisplayName() : null;
+            // there is another call up the stack that is creating BuildData for the same Run,
+            // so the initial caller will get fully populated data
+            // (empty data will only be used by the nested calls triggered by the original BuildData init)
             DatadogUtilities.severe(LOGGER, null, "BuildData creation is in progress for run " + runName + "; using empty data");
             return BuildData.EMPTY;
         }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/model/BuildData.java
@@ -61,8 +61,10 @@ import hudson.util.LogTaskListener;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -84,6 +86,67 @@ import org.datadog.jenkins.plugins.datadog.util.git.GitUtils;
 import org.jenkinsci.plugins.workflow.cps.EnvActionImpl;
 
 public class BuildData implements Serializable {
+
+    private static final BuildData EMPTY;
+
+    static {
+      try {
+          // exceptions below should never happen
+          // since constructor exists immediately if run is null
+          EMPTY = new BuildData(null, null);
+      } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException(e);
+      } catch (IOException e) {
+          throw new RuntimeException(e);
+      }
+    }
+
+    private static final ThreadLocal<Set<Run<?, ?>>> BUILD_DATA_BEING_CREATED = ThreadLocal.withInitial(BuildData::identityHashSet);
+
+    private static <T> Set<T> identityHashSet() {
+        return Collections.newSetFromMap(new IdentityHashMap<>());
+    }
+
+    /**
+     * This is a workaround for a BuildData initialization issue.
+     * <p>
+     * Some of the fields in this class are initialized with the values obtained from a Run instance.
+     * Querying Run fields can trigger run initialization in some cases (e.g. loading run data from disk when resuming a run after Jenkins restart).
+     * During run initialization some logs are written.
+     * Writing logs, in turn, requires creating a TaskListener associated with the run.
+     * Creating the listener triggers initialization of DatadogTaskListenerDecorator, as the listener's logger needs to be decorated.
+     * The decorator creates another BuildData instance, whose creation starts the whole cycle from the beginning.
+     * As the result, the code enters an endless cycle of initializing BuildData while initializing BuildData, which terminates with a stack overflow.
+     * <p>
+     * The code below checks that BuildData for the provided run is already being created in the current thread.
+     * If that is the case, empty BuildData instance is returned for the nested calls in order to break the cycle.
+     * As a side effect, whatever logs are written while Run instance is being initialized will not be tagged with that run's data.
+     */
+    // TODO split BuildData fields that are used by DatadogWriter into a separate class whose initialization will not trigger run data load
+    @Nonnull
+    public static BuildData create(@Nullable Run<?, ?> run, @Nullable TaskListener listener) {
+        if (!BUILD_DATA_BEING_CREATED.get().add(run)) {
+            String runName = run != null ? run.getDisplayName() : null;
+            DatadogUtilities.severe(LOGGER, null, "BuildData creation is in progress for run " + runName + "; using empty data");
+            return BuildData.EMPTY;
+        }
+        try {
+            return new BuildData(run, listener);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            DatadogUtilities.severe(LOGGER, e, "Interrupted while creating build data");
+            return BuildData.EMPTY;
+
+        } catch (Exception e) {
+            DatadogUtilities.severe(LOGGER, e, "Error creating build data");
+            return BuildData.EMPTY;
+
+        } finally {
+            BUILD_DATA_BEING_CREATED.get().remove(run);
+        }
+    }
 
     private static final long serialVersionUID = 1L;
 
@@ -186,7 +249,7 @@ public class BuildData implements Serializable {
     @Nullable
     private Long upstreamPipelineTraceId;
 
-    public BuildData(Run<?, ?> run, @Nullable TaskListener listener) throws IOException, InterruptedException {
+    private BuildData(Run<?, ?> run, @Nullable TaskListener listener) throws IOException, InterruptedException {
         if (run == null) {
             return;
         }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogTracePipelineLogic.java
@@ -43,7 +43,7 @@ public class DatadogTracePipelineLogic extends DatadogBasePipelineLogic {
     // hook for tests
     @Nonnull
     public TraceSpan toSpan(PipelineStepData current, Run<?, ?> run) throws IOException, InterruptedException {
-        BuildData buildData = new BuildData(run, DatadogUtilities.getTaskListener(run));
+        BuildData buildData = BuildData.create(run, DatadogUtilities.getTaskListener(run));
 
         final long startTimeNanos = TimeUnit.MILLISECONDS.toNanos(current.getStartTimeMillis());
         final long endTimeNanos = TimeUnit.MILLISECONDS.toNanos(current.getEndTimeMillis());

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookPipelineLogic.java
@@ -31,7 +31,7 @@ public class DatadogWebhookPipelineLogic extends DatadogBasePipelineLogic {
     @Nonnull
     @Override
     public JSONObject toJson(PipelineStepData current, Run<?, ?> run) throws IOException, InterruptedException {
-        BuildData buildData = new BuildData(run, DatadogUtilities.getTaskListener(run));
+        BuildData buildData = BuildData.create(run, DatadogUtilities.getTaskListener(run));
 
         JSONObject payload = new JSONObject();
         payload.put("partial_retry", false);

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalTagsTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalTagsTest.java
@@ -105,7 +105,7 @@ public class DatadogGlobalTagsTest {
       Run run = mock(Run.class);
       when(run.getResult()).thenReturn(null);
       when(run.getParent()).thenReturn(job);
-      when(run.getEnvironment(any())).thenReturn(new EnvVars());
+      when(run.getEnvironment(any(TaskListener.class))).thenReturn(new EnvVars());
 
       this.datadogBuildListener.onInitialize(run);
       assertAllJobMetricsAndEvents();

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalTagsTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalTagsTest.java
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 package org.datadog.jenkins.plugins.datadog;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -104,6 +105,7 @@ public class DatadogGlobalTagsTest {
       Run run = mock(Run.class);
       when(run.getResult()).thenReturn(null);
       when(run.getParent()).thenReturn(job);
+      when(run.getEnvironment(any())).thenReturn(new EnvVars());
 
       this.datadogBuildListener.onInitialize(run);
       assertAllJobMetricsAndEvents();

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalTagsTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogGlobalTagsTest.java
@@ -49,6 +49,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Test suite for global tags configuration of Jenkins plugin
@@ -106,6 +107,8 @@ public class DatadogGlobalTagsTest {
       when(run.getResult()).thenReturn(null);
       when(run.getParent()).thenReturn(job);
       when(run.getEnvironment(any(TaskListener.class))).thenReturn(new EnvVars());
+      when(run.getQueueId()).thenReturn(Run.QUEUE_ID_UNKNOWN);
+      when(run.getCharset()).thenReturn(StandardCharsets.UTF_8);
 
       this.datadogBuildListener.onInitialize(run);
       assertAllJobMetricsAndEvents();

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/events/BuildAbortedEventTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/events/BuildAbortedEventTest.java
@@ -59,7 +59,7 @@ public class BuildAbortedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new BuildAbortedEventImpl(bd);
 
@@ -92,7 +92,7 @@ public class BuildAbortedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new BuildAbortedEventImpl(bd);
 
@@ -124,7 +124,7 @@ public class BuildAbortedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new BuildAbortedEventImpl(bd);
 
@@ -156,7 +156,7 @@ public class BuildAbortedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new BuildAbortedEventImpl(bd);
 
@@ -187,7 +187,7 @@ public class BuildAbortedEventTest {
 
         TaskListener listener = mock(TaskListener.class);
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new BuildAbortedEventImpl(bd);
 
@@ -225,7 +225,7 @@ public class BuildAbortedEventTest {
 
         TaskListener listener = mock(TaskListener.class);
 
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname("test-hostname-2");
         bd.setJenkinsUrl("https://jenkins.com");
         DatadogEvent event = new BuildAbortedEventImpl(bd);
@@ -265,7 +265,7 @@ public class BuildAbortedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         Map<String, Set<String>> tags = new HashMap<>();
         tags = DatadogClientStub.addTagToMap(tags, "tag1", "value1");
         tags = DatadogClientStub.addTagToMap(tags, "tag2", "value2");

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/events/BuildFinishedEventTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/events/BuildFinishedEventTest.java
@@ -55,7 +55,7 @@ public class BuildFinishedEventTest {
         Run run = new BuildStub(job, null, null, null, 0L, 0, null, 0L, null);
 
         TaskListener listener = mock(TaskListener.class);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         DatadogEvent event = new BuildFinishedEventImpl(bd);
 
         String hostname = DatadogUtilities.getHostname(null);
@@ -85,7 +85,7 @@ public class BuildFinishedEventTest {
         Run run = new BuildStub(job, null, null, null, 0L, 0, null, 0L, null);
 
         TaskListener listener = mock(TaskListener.class);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         DatadogEvent event = new BuildFinishedEventImpl(bd);
 
         String hostname = DatadogUtilities.getHostname(null);
@@ -111,7 +111,7 @@ public class BuildFinishedEventTest {
         Run run = new BuildStub(job, null, null, null, 0L, 0, null, 0L, null);
 
         TaskListener listener = mock(TaskListener.class);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         DatadogEvent event = new BuildFinishedEventImpl(bd);
 
         String hostname = DatadogUtilities.getHostname(null);
@@ -137,7 +137,7 @@ public class BuildFinishedEventTest {
         Run run = new BuildStub(job, null, null, null, 0L, 0, null, 0L, null);
 
         TaskListener listener = mock(TaskListener.class);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         DatadogEvent event = new BuildFinishedEventImpl(bd);
 
         String hostname = DatadogUtilities.getHostname(null);
@@ -164,7 +164,7 @@ public class BuildFinishedEventTest {
         Run run = new BuildStub(job, Result.FAILURE, null, null, 0L, 0, null, 0L, null);
 
         TaskListener listener = mock(TaskListener.class);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         DatadogEvent event = new BuildFinishedEventImpl(bd);
 
         String hostname = DatadogUtilities.getHostname(null);
@@ -195,7 +195,7 @@ public class BuildFinishedEventTest {
         Run run = new BuildStub(job, Result.UNSTABLE, null, null, 0L, 0, null, 0L, null);
 
         TaskListener listener = mock(TaskListener.class);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         DatadogEvent event = new BuildFinishedEventImpl(bd);
 
         String hostname = DatadogUtilities.getHostname(null);
@@ -233,7 +233,7 @@ public class BuildFinishedEventTest {
 
         TaskListener listener = mock(TaskListener.class);
 
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname("test-hostname-2");
         bd.setJenkinsUrl("https://jenkins.com");
         DatadogEvent event = new BuildFinishedEventImpl(bd);
@@ -273,7 +273,7 @@ public class BuildFinishedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         Map<String, Set<String>> tags = new HashMap<>();
         tags = DatadogClientStub.addTagToMap(tags, "tag1", "value1");
         tags = DatadogClientStub.addTagToMap(tags, "tag2", "value2");

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/events/BuildStartedEventTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/events/BuildStartedEventTest.java
@@ -57,7 +57,7 @@ public class BuildStartedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new BuildStartedEventImpl(bd);
 
@@ -89,7 +89,7 @@ public class BuildStartedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new BuildStartedEventImpl(bd);
 
@@ -121,7 +121,7 @@ public class BuildStartedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new BuildStartedEventImpl(bd);
 
@@ -153,7 +153,7 @@ public class BuildStartedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new BuildStartedEventImpl(bd);
 
@@ -185,7 +185,7 @@ public class BuildStartedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new BuildStartedEventImpl(bd);
 
@@ -223,7 +223,7 @@ public class BuildStartedEventTest {
 
         TaskListener listener = mock(TaskListener.class);
 
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname("test-hostname-2");
         bd.setJenkinsUrl("https://jenkins.com");
         DatadogEvent event = new BuildStartedEventImpl(bd);
@@ -262,7 +262,7 @@ public class BuildStartedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         Map<String, Set<String>> tags = new HashMap<>();
         tags = DatadogClientStub.addTagToMap(tags, "tag1", "value1");
         tags = DatadogClientStub.addTagToMap(tags, "tag2", "value2");

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/events/SCMCheckoutCompletedEventTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/events/SCMCheckoutCompletedEventTest.java
@@ -57,7 +57,7 @@ public class SCMCheckoutCompletedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new SCMCheckoutCompletedEventImpl(bd);
 
@@ -89,7 +89,7 @@ public class SCMCheckoutCompletedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new SCMCheckoutCompletedEventImpl(bd);
 
@@ -121,7 +121,7 @@ public class SCMCheckoutCompletedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new SCMCheckoutCompletedEventImpl(bd);
 
@@ -153,7 +153,7 @@ public class SCMCheckoutCompletedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new SCMCheckoutCompletedEventImpl(bd);
 
@@ -185,7 +185,7 @@ public class SCMCheckoutCompletedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname(hostname);
         DatadogEvent event = new SCMCheckoutCompletedEventImpl(bd);
 
@@ -223,7 +223,7 @@ public class SCMCheckoutCompletedEventTest {
 
         TaskListener listener = mock(TaskListener.class);
 
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         bd.setHostname("test-hostname-2");
         bd.setJenkinsUrl("https://jenkins.com");
         DatadogEvent event = new SCMCheckoutCompletedEventImpl(bd);
@@ -262,7 +262,7 @@ public class SCMCheckoutCompletedEventTest {
         TaskListener listener = mock(TaskListener.class);
 
         String hostname = DatadogUtilities.getHostname(null);
-        BuildData bd = new BuildData(run, listener);
+        BuildData bd = BuildData.create(run, listener);
         Map<String, Set<String>> tags = new HashMap<>();
         tags = DatadogClientStub.addTagToMap(tags, "tag1", "value1");
         tags = DatadogClientStub.addTagToMap(tags, "tag2", "value2");

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/model/BuildDataTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/model/BuildDataTest.java
@@ -145,7 +145,7 @@ public class BuildDataTest {
 
     private BuildData whenCreatingBuildData(Run run) throws IOException, InterruptedException {
         TaskListener listener = mock(TaskListener.class);
-        return new BuildData(run, listener);
+        return BuildData.create(run, listener);
     }
 
     @Test


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Adds a workaround for a `BuildData` initialization issue.

Some of the fields in this `BuildData` are initialized with the values obtained from a `Run` instance.
Querying `Run` fields can trigger run initialization in some cases (e.g. loading run data from disk when resuming a run after Jenkins restart).
During run initialization some logs are written.
Writing logs, in turn, requires creating a `TaskListener` associated with the run.
Creating the listener triggers initialization of `DatadogTaskListenerDecorator`, as the listener's logger needs to be decorated.
The decorator creates another `BuildData` instance, whose creation starts the whole cycle from the beginning.
As the result, the code enters an endless cycle of initializing `BuildData` while initializing `BuildData`, which terminates with a stack overflow.

The added code checks that `BuildData` for the provided run is already being created in the current thread.
If that is the case, empty `BuildData` instance is returned for the nested calls in order to break the cycle.
As a side effect, whatever logs are written while Run instance is being initialized will not be tagged with that run's data.

It should fix the following issues:
https://github.com/jenkinsci/datadog-plugin/issues/484
https://github.com/jenkinsci/datadog-plugin/issues/389

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

