### PR TITLE
Do not submit running pipelines data until accurate start time is known

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListener.java
@@ -214,16 +214,9 @@ public class DatadogBuildListener extends RunListener<Run> {
             Metrics.getInstance().incrementCounter("jenkins.job.started", hostname, tags);
 
             if (DatadogUtilities.getDatadogGlobalDescriptor().getEnableCiVisibility()) {
-                // Do not submit start events for pipelines:
-                // the accurate start time for a pipeline is only known once the first step starts executing
-                // (everything before that counts as queued time).
-                // The backend relies on start time being consistent, so for pipelines
-                // we submit the first event when the "Start of Pipeline" FlowNode is encountered.
-                if (!(run instanceof WorkflowRun)) {
-                    TraceWriter traceWriter = TraceWriterFactory.getTraceWriter();
-                    if (traceWriter != null) {
-                        traceWriter.submitBuild(buildData, run);
-                    }
+                TraceWriter traceWriter = TraceWriterFactory.getTraceWriter();
+                if (traceWriter != null) {
+                    traceWriter.submitBuild(buildData, run);
                 }
             }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/DatadogWebhookBuildLogic.java
@@ -42,6 +42,13 @@ public class DatadogWebhookBuildLogic extends DatadogBaseBuildLogic {
             return null;
         }
 
+        // Do not submit pipeline trace if start time is not known:
+        // the backend relies on start time being constant
+        // (otherwise finished pipeline record will not converge with its running pipeline record)
+        if (!buildData.isStartTimeKnown()) {
+            return null;
+        }
+
         final String jenkinsResult = buildData.getResult("");
         final String status = buildData.isBuilding() ? CITags.STATUS_RUNNING : statusFromResult(jenkinsResult);
         final String prefix = PipelineStepData.StepType.PIPELINE.getTagName();


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Updates the code to not submit pipeline trace if its accurate start time is not known.
This is needed because the backend relies on start time being constant (otherwise the finished pipeline record will not converge with its running pipeline record).

The accurate start time for a pipeline (`WorkflowRun`) is only known once the first step starts executing.
Everything before that counts as queued time: for example, a pipeline might be waiting for available executor.

Previous version of the code simply avoided sending pipeline data inside the `#onStarted()` callback (since the callback is executed before the available executor check).
This is not always sufficient: other callbacks that happen before the first step execution (such as the SCM callback for checking out a shared library) need to be excluded as well.

The new approach is more robust, as it checks that the pipeline queue time has been calculated (which only happens once the pipeline leaves the buildable queue).

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

