### PR TITLE
Replace mockito-inline with mockito-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,14 +113,7 @@
     <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>3.4.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListenerTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/listeners/DatadogBuildListenerTest.java
@@ -48,7 +48,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 public class DatadogBuildListenerTest {


### PR DESCRIPTION
## Replace `mockito-inline` with `mockito-core`

In version 5.x mockito switched their default mockmaker to `mockito-inline` ([source](https://github.com/mockito/mockito/releases/tag/v5.0.0)).
The corresponding artifact became obsolete and can be replaced with `mockito-core`

This PR replaces / removes the artifact and switches on `mockito-core` and the version provided by the `bom` instead.

### Testing done

None. Rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue