### PR TITLE
Add stage flow node Id to environment contributor

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/TraceStepEnvironmentContributor.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/TraceStepEnvironmentContributor.java
@@ -1,6 +1,7 @@
 package org.datadog.jenkins.plugins.datadog.traces;
 
 import static org.datadog.jenkins.plugins.datadog.traces.TracerConstants.SPAN_ID_ENVVAR_KEY;
+import static org.datadog.jenkins.plugins.datadog.traces.TracerConstants.STAGE_ID_ENVVAR_KEY;
 import static org.datadog.jenkins.plugins.datadog.traces.TracerConstants.TRACE_ID_ENVVAR_KEY;
 
 import hudson.EnvVars;
@@ -12,6 +13,7 @@ import java.util.logging.Logger;
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
 import org.datadog.jenkins.plugins.datadog.model.TraceInfoAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepEnvironmentContributor;
@@ -63,6 +65,16 @@ public class TraceStepEnvironmentContributor extends StepEnvironmentContributor 
                     final String spanIdStr  = Long.toUnsignedString(spanId);
                     envs.put(SPAN_ID_ENVVAR_KEY, spanIdStr);
                     logger.fine("Set DD_CUSTOM_PARENT_ID="+spanIdStr+" for FlowNode: "+flowNode);
+                }
+
+                if (envs.get(STAGE_ID_ENVVAR_KEY) == null) {
+                    BlockStartNode enclosingStage = DatadogUtilities.getEnclosingStageNode(flowNode);
+                    if (enclosingStage != null) {
+                        Long stageSpanId = traceInfoAction.getOrCreate(enclosingStage.getId());
+                        final String stageSpanIdStr = Long.toUnsignedString(stageSpanId);
+                        envs.put(STAGE_ID_ENVVAR_KEY, stageSpanIdStr);
+                        logger.fine("Set DD_CUSTOM_STAGE_ID=" + stageSpanIdStr + " for FlowNode: " + flowNode);
+                    }
                 }
             }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/TraceStepEnvironmentContributor.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/TraceStepEnvironmentContributor.java
@@ -70,10 +70,8 @@ public class TraceStepEnvironmentContributor extends StepEnvironmentContributor 
                 if (envs.get(STAGE_ID_ENVVAR_KEY) == null) {
                     BlockStartNode enclosingStage = DatadogUtilities.getEnclosingStageNode(flowNode);
                     if (enclosingStage != null) {
-                        Long stageSpanId = traceInfoAction.getOrCreate(enclosingStage.getId());
-                        final String stageSpanIdStr = Long.toUnsignedString(stageSpanId);
-                        envs.put(STAGE_ID_ENVVAR_KEY, stageSpanIdStr);
-                        logger.fine("Set DD_CUSTOM_STAGE_ID=" + stageSpanIdStr + " for FlowNode: " + flowNode);
+                        envs.put(STAGE_ID_ENVVAR_KEY, enclosingStage.getId());
+                        logger.fine("Set DD_CUSTOM_STAGE_ID=" + enclosingStage.getId() + " for FlowNode: " + flowNode);
                     }
                 }
             }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/traces/TracerConstants.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/traces/TracerConstants.java
@@ -8,5 +8,6 @@ public final class TracerConstants {
     // These env vars will be used by datadog-ci CLI to continue the trace.
     public static final String TRACE_ID_ENVVAR_KEY = "DD_CUSTOM_TRACE_ID";
     public static final String SPAN_ID_ENVVAR_KEY = "DD_CUSTOM_PARENT_ID";
+    public static final String STAGE_ID_ENVVAR_KEY = "DD_CUSTOM_STAGE_ID";
 
 }

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/traces/TraceStepEnvironmentContributorIT.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/traces/TraceStepEnvironmentContributorIT.java
@@ -2,8 +2,10 @@ package org.datadog.jenkins.plugins.datadog.traces;
 
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import hudson.EnvVars;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
 import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -12,7 +14,6 @@ import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration;
 import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
 import org.datadog.jenkins.plugins.datadog.clients.ClientHolder;
 import org.datadog.jenkins.plugins.datadog.clients.DatadogClientStub;
-import hudson.slaves.EnvironmentVariablesNodeProperty;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -51,9 +52,9 @@ public class TraceStepEnvironmentContributorIT {
                     "  stages {\n" +
                     "    stage('MyStage') {\n" +
                     "      steps {\n" +
-                    "        sh 'echo STAGE_ID=$DD_CUSTOM_STAGE_ID'\n" +
-                    "        sh 'echo TRACE_ID=$DD_CUSTOM_TRACE_ID'\n" +
-                    "        sh 'echo PARENT_ID=$DD_CUSTOM_PARENT_ID'\n" +
+                    "        " + shellEcho("STAGE_ID", "DD_CUSTOM_STAGE_ID") + "\n" +
+                    "        " + shellEcho("TRACE_ID", "DD_CUSTOM_TRACE_ID") + "\n" +
+                    "        " + shellEcho("PARENT_ID", "DD_CUSTOM_PARENT_ID") + "\n" +
                     "      }\n" +
                     "    }\n" +
                     "  }\n" +
@@ -76,10 +77,11 @@ public class TraceStepEnvironmentContributorIT {
         WorkflowJob pipeline = jenkinsRule.jenkins.createProject(WorkflowJob.class, "testStageIdNotSet");
         try {
             pipeline.setDefinition(new CpsFlowDefinition("node {\n" +
-                    "  sh 'echo STAGE_ID_CHECK=${DD_CUSTOM_STAGE_ID:-UNSET}'\n" +
+                    "  " + shellEcho("STAGE_ID_CHECK", "DD_CUSTOM_STAGE_ID") + "\n" +
                     "}", true));
             WorkflowRun build = jenkinsRule.buildAndAssertSuccess(pipeline);
-            jenkinsRule.assertLogContains("STAGE_ID_CHECK=UNSET", build);
+            String log = JenkinsRule.getLog(build);
+            assertNull("DD_CUSTOM_STAGE_ID should not be set outside a stage", extractValue(log, "STAGE_ID_CHECK="));
         } finally {
             pipeline.delete();
         }
@@ -94,12 +96,12 @@ public class TraceStepEnvironmentContributorIT {
                     "  stages {\n" +
                     "    stage('Stage1') {\n" +
                     "      steps {\n" +
-                    "        sh 'echo STAGE1_ID=$DD_CUSTOM_STAGE_ID'\n" +
+                    "        " + shellEcho("STAGE1_ID", "DD_CUSTOM_STAGE_ID") + "\n" +
                     "      }\n" +
                     "    }\n" +
                     "    stage('Stage2') {\n" +
                     "      steps {\n" +
-                    "        sh 'echo STAGE2_ID=$DD_CUSTOM_STAGE_ID'\n" +
+                    "        " + shellEcho("STAGE2_ID", "DD_CUSTOM_STAGE_ID") + "\n" +
                     "      }\n" +
                     "    }\n" +
                     "  }\n" +
@@ -115,6 +117,16 @@ public class TraceStepEnvironmentContributorIT {
         } finally {
             pipeline.delete();
         }
+    }
+
+    private static boolean isRunningOnWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
+    }
+
+    private static String shellEcho(String label, String envVar) {
+        return isRunningOnWindows()
+                ? "bat 'echo " + label + "=%" + envVar + "%'"
+                : "sh 'echo " + label + "=$" + envVar + "'";
     }
 
     private static String extractValue(String log, String prefix) {

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/traces/TraceStepEnvironmentContributorIT.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/traces/TraceStepEnvironmentContributorIT.java
@@ -1,0 +1,128 @@
+package org.datadog.jenkins.plugins.datadog.traces;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import hudson.EnvVars;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import jenkins.model.Jenkins;
+import org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration;
+import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
+import org.datadog.jenkins.plugins.datadog.clients.ClientHolder;
+import org.datadog.jenkins.plugins.datadog.clients.DatadogClientStub;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class TraceStepEnvironmentContributorIT {
+
+    @ClassRule
+    public static final JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Before
+    public void beforeEach() throws IOException {
+        DatadogGlobalConfiguration cfg = DatadogUtilities.getDatadogGlobalDescriptor();
+        cfg.setEnableCiVisibility(true);
+        cfg.setCiInstanceName("testService");
+        cfg.setGlobalJobTags(null);
+        cfg.setGlobalTags(null);
+        EnvVars.masterEnvVars.remove("ENV_VAR");
+
+        DatadogClientStub clientStub = new DatadogClientStub();
+        ClientHolder.setClient(clientStub);
+
+        Jenkins jenkins = jenkinsRule.jenkins;
+        jenkins.getGlobalNodeProperties().remove(EnvironmentVariablesNodeProperty.class);
+    }
+
+    @Test
+    public void testStageIdSetWhenStepInsideStage() throws Exception {
+        WorkflowJob pipeline = jenkinsRule.jenkins.createProject(WorkflowJob.class, "testStageIdSet");
+        try {
+            pipeline.setDefinition(new CpsFlowDefinition("pipeline {\n" +
+                    "  agent any\n" +
+                    "  stages {\n" +
+                    "    stage('MyStage') {\n" +
+                    "      steps {\n" +
+                    "        sh 'echo STAGE_ID=$DD_CUSTOM_STAGE_ID'\n" +
+                    "        sh 'echo TRACE_ID=$DD_CUSTOM_TRACE_ID'\n" +
+                    "        sh 'echo PARENT_ID=$DD_CUSTOM_PARENT_ID'\n" +
+                    "      }\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}", true));
+            WorkflowRun build = jenkinsRule.buildAndAssertSuccess(pipeline);
+            String log = JenkinsRule.getLog(build);
+            String stageId = extractValue(log, "STAGE_ID=");
+            String traceId = extractValue(log, "TRACE_ID=");
+            String parentId = extractValue(log, "PARENT_ID=");
+            assertNotNull("DD_CUSTOM_STAGE_ID should be set inside a stage", stageId);
+            assertNotNull("DD_CUSTOM_TRACE_ID should be set inside a stage", traceId);
+            assertNotNull("DD_CUSTOM_PARENT_ID should be set inside a stage", parentId);
+        } finally {
+            pipeline.delete();
+        }
+    }
+
+    @Test
+    public void testStageIdNotSetWhenStepOutsideStage() throws Exception {
+        WorkflowJob pipeline = jenkinsRule.jenkins.createProject(WorkflowJob.class, "testStageIdNotSet");
+        try {
+            pipeline.setDefinition(new CpsFlowDefinition("node {\n" +
+                    "  sh 'echo STAGE_ID_CHECK=${DD_CUSTOM_STAGE_ID:-UNSET}'\n" +
+                    "}", true));
+            WorkflowRun build = jenkinsRule.buildAndAssertSuccess(pipeline);
+            jenkinsRule.assertLogContains("STAGE_ID_CHECK=UNSET", build);
+        } finally {
+            pipeline.delete();
+        }
+    }
+
+    @Test
+    public void testDifferentStagesGetDifferentStageIds() throws Exception {
+        WorkflowJob pipeline = jenkinsRule.jenkins.createProject(WorkflowJob.class, "testDifferentStageIds");
+        try {
+            pipeline.setDefinition(new CpsFlowDefinition("pipeline {\n" +
+                    "  agent any\n" +
+                    "  stages {\n" +
+                    "    stage('Stage1') {\n" +
+                    "      steps {\n" +
+                    "        sh 'echo STAGE1_ID=$DD_CUSTOM_STAGE_ID'\n" +
+                    "      }\n" +
+                    "    }\n" +
+                    "    stage('Stage2') {\n" +
+                    "      steps {\n" +
+                    "        sh 'echo STAGE2_ID=$DD_CUSTOM_STAGE_ID'\n" +
+                    "      }\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}", true));
+            WorkflowRun build = jenkinsRule.buildAndAssertSuccess(pipeline);
+
+            String log = JenkinsRule.getLog(build);
+            String stage1Id = extractValue(log, "STAGE1_ID=");
+            String stage2Id = extractValue(log, "STAGE2_ID=");
+            assertNotNull("DD_CUSTOM_STAGE_ID should be set for Stage1", stage1Id);
+            assertNotNull("DD_CUSTOM_STAGE_ID should be set for Stage2", stage2Id);
+            assertNotEquals("Stage IDs for different stages should be different", stage1Id, stage2Id);
+        } finally {
+            pipeline.delete();
+        }
+    }
+
+    private static String extractValue(String log, String prefix) {
+        Pattern pattern = Pattern.compile(Pattern.quote(prefix) + "(\\d+)");
+        Matcher matcher = pattern.matcher(log);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Goal is to add the stage ID in the environment so that datadog-ci can later send custom tags for the stage level too

### Description of the Change

Adds the flow node ID of the stage, if any, into the env variable `DD_CUSTOM_STAGE_ID`. The rest of the changes will be handled in datadog-ci and the backend

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

