### PR TITLE
Fix flaky test: testAllQueueMetrics

### DIFF
--- a/src/test/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogQueuePublisherTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogQueuePublisherTest.java
@@ -27,11 +27,11 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
 
 public class DatadogQueuePublisherTest {
-    @ClassRule 
+    @ClassRule
     public static JenkinsRule jenkins = new JenkinsRule();
     public DatadogClientStub client;
     DatadogQueuePublisher queuePublisher = new DatadogQueuePublisher();
-    
+
     @Before
     public void setup() throws Exception {
         client = new DatadogClientStub();
@@ -46,7 +46,7 @@ public class DatadogQueuePublisherTest {
         final FreeStyleProject project = jenkins.createFreeStyleProject();
         String displayName = project.getDisplayName();
         project.getBuildersList().add(new SleepBuilder(10000));
-        
+
         jenkins.jenkins.getQueue().schedule(project);
 
         // set all the computers offline so they can't execute any buils, filling up the queue
@@ -109,14 +109,14 @@ public class DatadogQueuePublisherTest {
             globalConfiguration.setExcluded(previousExcludedPattern);
         }
     }
-    
+
     @Test
     public void testQueueMetricsMultipleBuilds() throws Exception {
         String hostname = DatadogUtilities.getHostname(null);
         final FreeStyleProject project = jenkins.createFreeStyleProject();
         String displayName = project.getDisplayName();
         project.getBuildersList().add(new SleepBuilder(10000));
-        
+
         for (int i = 0; i < 10; i++) {
             project.scheduleBuild(0, new Cause.RemoteCause("host",String.valueOf(i)), new ParametersAction(new StringParameterValue("param", String.valueOf(i))));
         }
@@ -125,22 +125,22 @@ public class DatadogQueuePublisherTest {
         for (Computer computer: jenkins.jenkins.getComputers()){
             computer.setTemporarilyOffline(true, OfflineCause.create(Messages._Hudson_Computer_DisplayName()));
         }
-        
+
         final String[] expectedTags = new String[2];
         expectedTags[0] = "jenkins_url:" + jenkins.getURL().toString();
         expectedTags[1] = "job_name:" + displayName;
         queuePublisher.doRun();
-        
+
         // Since the same job is in the queue multiple times, then its metric should be submitted multiple times
         client.assertMetric("jenkins.queue.job.in_queue", 1, hostname, expectedTags);
         client.assertMetric("jenkins.queue.job.in_queue", 1, hostname, expectedTags);
         client.assertMetric("jenkins.queue.job.in_queue", 1, hostname, expectedTags);
     }
-    
+
     @Test
     public void testQueueMetricsMultipleProjects() throws Exception {
         String hostname = DatadogUtilities.getHostname(null);
-       
+
         String displayName = "";
         for (int i = 0; i < 10; i++) {
             FreeStyleProject project = jenkins.createFreeStyleProject();
@@ -153,35 +153,35 @@ public class DatadogQueuePublisherTest {
         for (Computer computer: jenkins.jenkins.getComputers()){
             computer.setTemporarilyOffline(true, OfflineCause.create(Messages._Hudson_Computer_DisplayName()));
         }
-            
+
         final String[] expectedTags = new String[2];
         expectedTags[0] = "jenkins_url:" + jenkins.getURL().toString();
         expectedTags[1] = "job_name:test7";
-        
+
         final String[] expectedTags1 = Arrays.copyOf(expectedTags, 2);
         expectedTags1[1] = "job_name:test8";
         final String[] expectedTags2 = Arrays.copyOf(expectedTags, 2);
         expectedTags2[1] = "job_name:test9";
 
-        
+
         queuePublisher.doRun();
         // Make sure metrics are submitted for all jobs when there are multiple jobs.
         client.assertMetric("jenkins.queue.job.in_queue", 1, hostname, expectedTags);
         client.assertMetric("jenkins.queue.job.in_queue", 1, hostname, expectedTags1);
         client.assertMetric("jenkins.queue.job.in_queue", 1, hostname, expectedTags2);
-        
+
         client.assertMetric("jenkins.queue.job.pending", 0, hostname, expectedTags);
         client.assertMetric("jenkins.queue.job.pending", 0, hostname, expectedTags1);
         client.assertMetric("jenkins.queue.job.pending", 0, hostname, expectedTags2);
-        
+
         client.assertMetric("jenkins.queue.job.stuck", 1, hostname, expectedTags);
         client.assertMetric("jenkins.queue.job.stuck", 1, hostname, expectedTags1);
         client.assertMetric("jenkins.queue.job.stuck", 1, hostname, expectedTags2);
-        
+
         client.assertMetric("jenkins.queue.job.blocked", 0, hostname, expectedTags);
         client.assertMetric("jenkins.queue.job.blocked", 0, hostname, expectedTags1);
         client.assertMetric("jenkins.queue.job.blocked", 0, hostname, expectedTags2);
-        
+
         client.assertMetric("jenkins.queue.job.buildable", 1, hostname, expectedTags);
         client.assertMetric("jenkins.queue.job.buildable", 1, hostname, expectedTags1);
         client.assertMetric("jenkins.queue.job.buildable", 1, hostname, expectedTags2);
@@ -190,37 +190,46 @@ public class DatadogQueuePublisherTest {
     @Test
     public void testAllQueueMetrics() throws Exception {
         String hostname = DatadogUtilities.getHostname(null);
-        
-        String displayName = "";
+
+        // set all the computers offline before scheduling builds so no executor can pick up a job
+        for (Computer computer: jenkins.jenkins.getComputers()){
+            computer.setTemporarilyOffline(true, OfflineCause.create(Messages._Hudson_Computer_DisplayName()));
+        }
+
         for (int i = 0; i < 10; i++) {
             FreeStyleProject project = jenkins.createFreeStyleProject();
-            displayName = project.getDisplayName();
             project.getBuildersList().add(new SleepBuilder(10000));
             project.scheduleBuild(0, new Cause.RemoteCause("host",String.valueOf(i)), new ParametersAction(new StringParameterValue("param", String.valueOf(i))));
         }
 
-        // set all the computers offline so they can't execute any builds, filling up the queue
-        for (Computer computer: jenkins.jenkins.getComputers()){
-            computer.setTemporarilyOffline(true, OfflineCause.create(Messages._Hudson_Computer_DisplayName()));
+        // Wait for all queue items to transition to buildable state
+        // (Starts in an initial/pending state and transitions to "buildable" when Jenkins realizes no executor is available)
+        Queue queue = jenkins.jenkins.getQueue();
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (queue.countBuildableItems() < queue.getItems().length) {
+            if (System.currentTimeMillis() > deadline) {
+                throw new AssertionError("Timed out waiting for all queue items to become buildable. " +
+                        "Buildable: " + queue.countBuildableItems() + ", Total: " + queue.getItems().length);
+            }
+            Thread.sleep(100);
         }
-                
+
         final String[] expectedTags = new String[1];
         expectedTags[0] = "jenkins_url:" + jenkins.getURL().toString();
-        
+
+        int size = queue.getItems().length;
+        int buildable = queue.countBuildableItems();
+        int pending = queue.getPendingItems().size();
+
         queuePublisher.doRun();
-    
-        Queue queueStats = jenkins.jenkins.getQueue();
-        int size = queueStats.getItems().length;
-        int buildable = queueStats.countBuildableItems();
-        int pending = queueStats.getPendingItems().size();
-        
+
         // Make sure values are consistent across jenkins.queue.* and jenkins.queue.job.* metrics
         client.assertMetric("jenkins.queue.size", size, hostname, expectedTags);
         client.assertMetricValuesMin("jenkins.queue.job.in_queue", 1, hostname, size);
-        
+
         client.assertMetric("jenkins.queue.buildable", size, hostname, expectedTags);
         client.assertMetricValuesMin("jenkins.queue.job.buildable", 1, hostname, buildable);
-        
+
         client.assertMetric("jenkins.queue.pending", pending, hostname, expectedTags);
         client.assertMetricValues("jenkins.queue.job.pending", 1, hostname, pending);
         client.assertMetricValuesMin("jenkins.queue.job.pending", 0, hostname, size);


### PR DESCRIPTION
### What does this PR do?
Fixes the `testAllQueueMetrics` flaky test.


### Description of the Change

The test testAllQueueMetrics had two race conditions:

  1. Schedule-before-offline race: Jobs were scheduled before computers were set offline, so an executor could pick
  up a job (or a job wouldn't yet be in buildable state) before the offline took effect. In the failing run, test22
  had buildable=0 while the other 9 had buildable=1.
  2. Async state transition: scheduleBuild() returns before Jenkins' queue maintenance thread transitions items from
  pending to buildable. Calling doRun() immediately could sample metrics before all items reached buildable state.

  The fix: set computers offline first, poll until all items are buildable, then query state and sample metrics.


### Verification Process

Ran the test 5 times and it passed all 5 times.


### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

